### PR TITLE
[fix] @ValidateNested() used to throw Error when the property being v…

### DIFF
--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -204,8 +204,6 @@ export class ValidationExecutor {
             } else if (value instanceof Object) {
                 this.execute(value, targetSchema, errors);
 
-            } else {
-                throw new Error("Only objects and arrays are supported to nested validation");
             }
         });
     }


### PR DESCRIPTION
@ValidateNested() used to throw Error when the property being validated is not an object. This causes all the other validation errors to be ignored, and returning exception with no details regarding this validation error. This fix removes the error throw, and can be used together with custom "IsObject" validator to add indicative ValidationError