### PR TITLE
Fix for issue #57: @length(), default message wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In our case, when we validated a Post object, we have such array of ValidationEr
     property: "title",
     value: "Hello",
     constraints: {
-        length: "$property must be longer than 10 characters"
+        length: "$property must be longer than or equal to 10 characters"
     }
 }, {
     target: /* post object */,

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -226,11 +226,11 @@ export class ValidationTypes {
                     const isMinLength = args.constraints[0] !== null && args.constraints[0] !== undefined;
                     const isMaxLength = args.constraints[1] !== null && args.constraints[1] !== undefined;
                     if (isMinLength && (!args.value || args.value.length < args.constraints[0])) {
-                        return eachPrefix + "$property must be longer than $constraint1 characters";
+                        return eachPrefix + "$property must be longer than or equal to $constraint1 characters";
                     } else if (isMaxLength && (args.value.length > args.constraints[1])) {
-                        return eachPrefix + "$property must be shorter than $constraint2 characters";
+                        return eachPrefix + "$property must be shorter than or equal to $constraint2 characters";
                     }
-                    return eachPrefix + "$property must be longer than $constraint1 and shorter than $constraint2 characters";
+                    return eachPrefix + "$property must be longer than or equal to $constraint1 and shorter than or equal to $constraint2 characters";
                 };
             case this.MIN_LENGTH:
                 return eachPrefix + "$property must be longer than or equal to $constraint1 characters";

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -2656,13 +2656,13 @@ describe("Length", function() {
 
     it("should return error object with proper data", function(done) {
         const validationType = "length";
-        const message = "someProperty must be longer than " + constraint1 + " characters";
+        const message = "someProperty must be longer than or equal to " + constraint1 + " characters";
         checkReturnedError(new MyClass(), ["", "a"], validationType, message, done);
     });
 
     it("should return error object with proper data", function(done) {
         const validationType = "length";
-        const message = "someProperty must be shorter than " + constraint2 + " characters";
+        const message = "someProperty must be shorter than or equal to " + constraint2 + " characters";
         checkReturnedError(new MyClass(), ["aaaa", "azzazza"], validationType, message, done);
     });
 


### PR DESCRIPTION
This is a Pull Request to address the issue identified in issue #57.

This Pull Request updates the default message for `@Length` as follows:
- `must be longer than` updated to `must be longer than or equal to`
- `must be shorter than` updated to `must be shorter than or equal to`
 