### PR TITLE
add options `alwaysDefault` and `strictGroups` for validation

### DIFF
--- a/src/metadata/ValidationMetadata.ts
+++ b/src/metadata/ValidationMetadata.ts
@@ -48,7 +48,7 @@ export class ValidationMetadata {
     /**
      * Indicates if validation must be performed always, no matter of validation groups used.
      */
-    always: boolean = false;
+    always?: boolean;
 
     /**
      * Specifies if validated value is an array and each of its item must be validated.

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -41,7 +41,12 @@ export class ValidationExecutor {
 
     execute(object: Object, targetSchema: string, validationErrors: ValidationError[]) {
         const groups = this.validatorOptions ? this.validatorOptions.groups : undefined;
-        const targetMetadatas = this.metadataStorage.getTargetValidationMetadatas(object.constructor, targetSchema, groups);
+        const strictGroups = this.validatorOptions && this.validatorOptions.strictGroups || false;
+        const alwaysDefault = this.validatorOptions && this.validatorOptions.alwaysDefault || false;
+
+        const targetMetadatas = this.metadataStorage.getTargetValidationMetadatas(
+            object.constructor, targetSchema, alwaysDefault, strictGroups, groups
+        );
         const groupedMetadatas = this.metadataStorage.groupByPropertyName(targetMetadatas);
 
         Object.keys(groupedMetadatas).forEach(propertyName => {

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -14,6 +14,17 @@ export interface ValidatorOptions {
     groups?: string[];
 
     /**
+     * Set default for `always` option of decorators. Default can be overridden in decorator options.
+     * Decorators with `groups` option do not get a default.
+     */
+    alwaysDefault?: boolean;
+
+    /**
+     * If `groups` does not exist or is empty ignore decorators with `groups` option.
+     */
+    strictGroups?: boolean;
+
+    /**
      * If set to true, the validation will not use default messages.
      * Error message always will be undefined if its not explicitly set.
      */


### PR DESCRIPTION
I found the way groups work to give me some unexpected behaviour. 

For one I was surprised that when validating without groups, decorators which have the `groups` option are included. The added `strictGroups` option only includes decorators without groups in the validation.

When set to `true` `alwaysDefault` includes all decorators without groups when validating with groups. 

For my use cases setting both options to true is what I need most of the time and would be what I find is more intuitive, but that might just be me. For backwards compatibility, both options are `false` per default.

references #60
  