### PR TITLE
Fixed case when validationArguments.value is not string

### DIFF
--- a/src/validation/ValidationUtils.ts
+++ b/src/validation/ValidationUtils.ts
@@ -19,7 +19,7 @@ export class ValidationUtils {
             });
         }
 
-        if (messageString && validationArguments.value !== undefined && validationArguments.value !== null)
+        if (messageString && validationArguments.value !== undefined && validationArguments.value !== null && typeof validationArguments.value === "string")
             messageString = messageString.replace(/\$value/g, validationArguments.value);
         if (messageString)
             messageString = messageString.replace(/\$property/g, validationArguments.property);


### PR DESCRIPTION
When **validationArguments.value** is not string it tries to replace parts of message (labeled with $value) and produces error