### PR TITLE
Fix documentation on custom decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ Lets create a decorator called `@IsLongerThan`:
         title: string;
 
         @IsLongerThan("title", {
-           /* you can also use additional validation options, like "each", "groups" in your custom validation decorators */
+           /* you can also use additional validation options, like "groups" in your custom validation decorators. "each" is not supported */
            message: "Text must be longer than the title"
         })
         text: string;


### PR DESCRIPTION
'each' is not supported for custom decorators. 
We do not check for each in metadata and do not handle it like here https://github.com/typestack/class-validator/blob/master/src/validation/ValidationExecutor.ts#L190

Take a look at https://github.com/typestack/class-validator/blob/master/src/validation/ValidationExecutor.ts#L213