### PR TITLE
Update IsURLOptions to match underlying validator host list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* update `IsURLOptions` to match underlying validator host list options
 * added a console warning when no metadata decorator is found as it's possibly not intended
 
 ## 0.8.5

--- a/src/validation/ValidationTypeOptions.ts
+++ b/src/validation/ValidationTypeOptions.ts
@@ -33,8 +33,8 @@ export interface IsURLOptions {
     require_protocol?: boolean;
     require_valid_protocol?: boolean;
     allow_underscores?: boolean;
-    host_whitelist?: false | string[];
-    host_blacklist?: false | string[];
+    host_whitelist?: false | (string | RegExp)[];
+    host_blacklist?: false | (string | RegExp)[];
     allow_trailing_dot?: boolean;
     allow_protocol_relative_urls?: boolean;
 }


### PR DESCRIPTION
This updates the options that can be passed into `IsURL` to allow RegExp patterns to be supplied to whitelist and blacklist hosts. Currently only an array of strings are specified, but the underlying implementation checks RegExp as well: https://github.com/chriso/validator.js/blob/master/src/lib/isURL.js#L27