### PR TITLE
detailed/extended error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export interface ValidatorOptions {
     property: string; // Object's property that haven't pass validation.
     value: any; // Value that haven't pass a validation.
     constraints?: { // Constraints that failed validation with error messages.
-        [type: string]: string;
+        [type: string]: string | ExtendedMessage;
     };
     children?: ValidationError[]; // Contains all nested validation errors of the property
 }
@@ -151,6 +151,37 @@ In our case, when we validated a Post object, we have such array of ValidationEr
 // and other errors
 ]
 ```
+
+If you want to build your own error messages (e.g. in an internationalized app), the ExtendedMessage comes into play: 
+you get back all constraint parameters:
+```typescript
+validator.validate(data, { validationError: { extendedMessage: true } });
+```
+The parameter 'detailedMessage' will cause all constraints to have an ExtendedError instead of the plain string message.
+
+So an input of this type:
+```typescript
+export class Post {
+    @MinLength(10)
+    title: string = "Hello"
+}
+```
+will yield e.g.:
+```typescript
+[{
+    target: /* post object */,
+    property: "title",
+    value: "Hello",
+    constraints: {
+        minLength: {
+            type: "minLength",
+            args: [10],
+            message: "title must be longer than or equal to 10 characters"
+        }
+    }
+}]
+```
+Together with [passing context to decorators](#passing-context-to-decorators), the error messages are fully customizable.
 
 If you don't want a `target` to be exposed in validation errors, there is a special option when you use validator:
 

--- a/src/validation/ExtendedMessage.ts
+++ b/src/validation/ExtendedMessage.ts
@@ -1,0 +1,12 @@
+/**
+ * Contains necessary information to present good error messages to the user
+ */
+export class ExtendedMessage {
+    constructor(
+        public readonly type: string,
+        public readonly message: string,
+        public readonly args: any[]
+    ) {
+        // nop
+    }
+}

--- a/src/validation/ValidationError.ts
+++ b/src/validation/ValidationError.ts
@@ -1,6 +1,8 @@
 /**
  * Validation error description.
  */
+import {ExtendedMessage} from "./ExtendedMessage";
+
 export class ValidationError {
 
     /**
@@ -26,7 +28,7 @@ export class ValidationError {
      * Constraints that failed validation with error messages.
      */
     constraints: {
-        [type: string]: string
+        [type: string]: string | ExtendedMessage
     };
 
     /**

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -195,7 +195,7 @@ export class ValidationExecutor {
     }
 
     private buildExtendedMessage(metadata: ValidationMetadata, message: string, customConstraintMetadata?: ConstraintMetadata): string | ExtendedMessage {
-        if (this.validatorOptions.validationError && this.validatorOptions.validationError.detailedMessage) {
+        if (this.validatorOptions.validationError && this.validatorOptions.validationError.extendedMessage) {
             const type = this.getConstraintType(metadata, customConstraintMetadata);
             return new ExtendedMessage(type, message, metadata.constraints || []);
         } else {

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -46,11 +46,16 @@ export interface ValidatorOptions {
          */
         value?: boolean;
 
+        /**
+         * use ExtendedMessage instead of sring message in ValidationError
+         */
+         extendedMessage?: boolean;
     };
 
     /**
      * Settings true will cause fail validation of unknown objects.
      */
     forbidUnknownValues?: boolean;
+
 
 }

--- a/test/functional/ExtendedMessage.spec.ts
+++ b/test/functional/ExtendedMessage.spec.ts
@@ -1,5 +1,10 @@
 import "es6-shim";
-import {ValidationArguments, Validator, ValidatorConstraint, ValidatorConstraintInterface} from "../../src";
+import {
+    ValidationArguments,
+    Validator,
+    ValidatorConstraint,
+    ValidatorConstraintInterface, ValidatorOptions
+} from "../../src";
 import {MinLength} from "../../src";
 
 import {should, use} from "chai";
@@ -11,7 +16,7 @@ should();
 use(chaiAsPromised);
 
 const validator = new Validator();
-const DETAILS_ENABLED = {validationError: {detailedMessage: true}};
+const DETAILS_ENABLED: ValidatorOptions = {validationError: {extendedMessage: true}};
 
 class StandardValidation {
     @MinLength(10)
@@ -47,7 +52,7 @@ describe("ExtendedMessage", () => {
             // given
             const fixture = new StandardValidation();
             // when
-            const errors = validator.validateSync(fixture, {validationError: {detailedMessage: false}});
+            const errors = validator.validateSync(fixture, {validationError: {extendedMessage: false}});
             // then
             errors[0].constraints.should.be.eql({minLength: "text must be longer than or equal to 10 characters"});
         });

--- a/test/functional/ExtendedMessage.spec.ts
+++ b/test/functional/ExtendedMessage.spec.ts
@@ -1,0 +1,139 @@
+import "es6-shim";
+import {ValidationArguments, Validator, ValidatorConstraint, ValidatorConstraintInterface} from "../../src";
+import {MinLength} from "../../src";
+
+import {should, use} from "chai";
+
+import * as chaiAsPromised from "chai-as-promised";
+import {Validate} from "../../src";
+
+should();
+use(chaiAsPromised);
+
+const validator = new Validator();
+const DETAILS_ENABLED = {validationError: {detailedMessage: true}};
+
+class StandardValidation {
+    @MinLength(10)
+    public readonly text: string = "invalid";
+}
+
+@ValidatorConstraint({name: "customText", async: false})
+export class CustomTextLength implements ValidatorConstraintInterface {
+
+    validate(text: string, args: ValidationArguments) {
+        return text.length > (args.constraints || [10])[0];
+    }
+
+    defaultMessage(args: ValidationArguments) { // here you can provide default error message if validation failed
+        return "Text ($value) is too short or too long: " + (args.constraints || [10])[0];
+    }
+
+}
+
+describe("ExtendedMessage", () => {
+
+    describe("disabled", () => {
+        it("validates with simple message with default options", () => {
+            // given
+            const fixture = new StandardValidation();
+            // when
+            const errors = validator.validateSync(fixture);
+            // then
+            errors[0].constraints.should.be.eql({minLength: "text must be longer than or equal to 10 characters"});
+        });
+
+        it("validates with simple message with option disabled", () => {
+            // given
+            const fixture = new StandardValidation();
+            // when
+            const errors = validator.validateSync(fixture, {validationError: {detailedMessage: false}});
+            // then
+            errors[0].constraints.should.be.eql({minLength: "text must be longer than or equal to 10 characters"});
+        });
+
+    });
+
+    describe("with standard validations", () => {
+        it("validates with extended message", () => {
+            // given
+            const fixture = new StandardValidation();
+            // when
+            const errors = validator.validateSync(fixture, DETAILS_ENABLED);
+            // then
+            errors[0].constraints.should.be.eql({
+                minLength: {
+                    type: "minLength",
+                    args: [10],
+                    message: "text must be longer than or equal to 10 characters"
+                }
+            });
+        });
+    });
+
+    describe("with custom validator", () => {
+        it("validates with extended message (no arguments)", () => {
+            // given
+            class CustomValidation {
+                @Validate(CustomTextLength)
+                public readonly text: string = "invalid";
+            }
+            const fixture = new CustomValidation();
+
+            // when
+            const errors = validator.validateSync(fixture, DETAILS_ENABLED);
+
+            // then
+            errors[0].constraints.should.be.eql({
+                customText: {
+                    type: "customText",
+                    args: [],
+                    message: "Text (invalid) is too short or too long: 10"
+                }
+            });
+        });
+
+        it("validates with extended message (with arguments)", () => {
+            // given
+            class CustomValidation {
+                @Validate(CustomTextLength, [20])
+                public readonly text: string = "invalid";
+            }
+            const fixture = new CustomValidation();
+
+            // when
+            const errors = validator.validateSync(fixture, DETAILS_ENABLED);
+
+            // then
+            errors[0].constraints.should.be.eql({
+                customText: {
+                    type: "customText",
+                    args: [20],
+                    message: "Text (invalid) is too short or too long: 20"
+                }
+            });
+        });
+
+        it("validates with extended message (handles 'undefined' argument)", () => {
+            // given
+            class CustomValidation {
+                @Validate(CustomTextLength, [undefined])
+                public readonly text: string = "invalid";
+            }
+            const fixture = new CustomValidation();
+
+            // when
+            const errors = validator.validateSync(fixture, DETAILS_ENABLED);
+
+            // then
+            errors[0].constraints.should.be.eql({
+                customText: {
+                    type: "customText",
+                    args: [undefined],
+                    message: "Text (invalid) is too short or too long: undefined"
+                }
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
return constraint args in ValidationError in a backwards compatible way.

Might help a lot with: 
- How to make it multi language #230
- How to customize validation messages globally? #169


