### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+build/
+node_modules/
+coverage/
+npm-debug.log
+*.iml
+.idea/
+
+*.js.map


### PR DESCRIPTION
I don't believe you need to publish the `js.map` files.
This will avoid publishing those files to npm along with everything else in your gitignore.

See [class-validator](https://packagephobia.now.sh/result?p=class-validator) size over time.