### PR TITLE
Automatically validating properties on assignment

### DIFF
--- a/sample/sample8-automatic-validation/Post.ts
+++ b/sample/sample8-automatic-validation/Post.ts
@@ -1,0 +1,39 @@
+import {Contains, IsInt, MinLength, MaxLength, IsEmail, IsFQDN, IsDate, ArrayNotEmpty, ArrayMinSize, ArrayMaxSize, IsEnum, AutoValidate} from "../../src/decorator/decorators";
+
+export enum PostType {
+    Public,
+    Private
+}
+
+@AutoValidate()
+export class Post {
+
+    @MinLength(10)
+    @MaxLength(20)
+    title: string;
+
+    @Contains("hello")
+    text: string;
+
+    @IsInt()
+    rating: number;
+
+    @IsEmail()
+    email: string;
+
+    @IsFQDN()
+    site: string;
+
+    @IsDate()
+    createDate: Date;
+
+    @ArrayNotEmpty()
+    @ArrayMinSize(2)
+    @ArrayMaxSize(5)
+    @MinLength(3, { each: true, message: "Tag is too short. Minimal length is $value characters" })
+    @MaxLength(50, { each: true, message: "Tag is too long. Maximal length is $value characters" })
+    tags: string[];
+
+    @IsEnum(PostType)
+    type: PostType;
+}

--- a/sample/sample8-automatic-validation/app.ts
+++ b/sample/sample8-automatic-validation/app.ts
@@ -12,15 +12,18 @@ post1.site = "google.com"; // should pass
 post1.createDate = new Date(); // should pass
 post1.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"]; // should pass
 post1.type = PostType.Private;
+console.log("Created post1 successfully");
 
 
 let post2 = new Post();
-
+const post2errors = [];
 try {
     post2.title = "Hello"; // should not pass
     throw new Error("Assignment should not pass");
 } catch (error) {
-    if (!(error instanceof ValidationError)) {
+    if (error instanceof ValidationError) {
+        post2errors.push(error);
+    } else {
         throw error;
     }
 }
@@ -28,7 +31,9 @@ try {
     post2.text = "this is a great post about hell world"; // should not pass
     throw new Error("Assignment should not pass");
 } catch (error) {
-    if (!(error instanceof ValidationError)) {
+    if (error instanceof ValidationError) {
+        post2errors.push(error);
+    } else {
         throw error;
     }
 }
@@ -36,7 +41,9 @@ try {
     post2.rating = 1.1; // should not pass
     throw new Error("Assignment should not pass");
 } catch (error) {
-    if (!(error instanceof ValidationError)) {
+    if (error instanceof ValidationError) {
+        post2errors.push(error);
+    } else {
         throw error;
     }
 }
@@ -44,7 +51,9 @@ try {
     post2.email = "google.com"; // should not pass
     throw new Error("Assignment should not pass");
 } catch (error) {
-    if (!(error instanceof ValidationError)) {
+    if (error instanceof ValidationError) {
+        post2errors.push(error);
+    } else {
         throw error;
     }
 }
@@ -52,7 +61,37 @@ try {
     post2.site = "googlecom"; // should not pass
     throw new Error("Assignment should not pass");
 } catch (error) {
-    if (!(error instanceof ValidationError)) {
+    if (error instanceof ValidationError) {
+        post2errors.push(error);
+    } else {
         throw error;
     }
 }
+
+try {
+    post2.createDate = undefined; // should not pass
+    throw new Error("Assignment should not pass");
+} catch (error) {
+    if (error instanceof ValidationError) {
+        post2errors.push(error);
+    } else {
+        throw error;
+    }
+}
+
+console.log("Post 2 successfully got validation errors", post2errors);
+
+
+let post3 = new Post();
+Object.assign(post3, {
+    title: "Hello world",
+    text: "this is a great post about hello world",
+    rating: 10,
+    email: "info@google.com",
+    site: "google.com",
+    createDate: new Date(),
+    tags: ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"],
+    type: PostType.Private,
+});
+
+console.log("Created post3 successfully");

--- a/sample/sample8-automatic-validation/app.ts
+++ b/sample/sample8-automatic-validation/app.ts
@@ -1,0 +1,58 @@
+import {validate, ValidationError} from "../../src/index";
+import {Post, PostType} from "./Post";
+
+// Sample8. automatic validation
+
+let post1 = new Post();
+post1.title = "Hello world"; // should pass
+post1.text = "this is a great post about hello world"; // should pass
+post1.rating = 10; // should pass
+post1.email = "info@google.com"; // should pass
+post1.site = "google.com"; // should pass
+post1.createDate = new Date(); // should pass
+post1.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"]; // should pass
+post1.type = PostType.Private;
+
+
+let post2 = new Post();
+
+try {
+    post2.title = "Hello"; // should not pass
+    throw new Error("Assignment should not pass");
+} catch (error) {
+    if (!(error instanceof ValidationError)) {
+        throw error;
+    }
+}
+try {
+    post2.text = "this is a great post about hell world"; // should not pass
+    throw new Error("Assignment should not pass");
+} catch (error) {
+    if (!(error instanceof ValidationError)) {
+        throw error;
+    }
+}
+try {
+    post2.rating = 1.1; // should not pass
+    throw new Error("Assignment should not pass");
+} catch (error) {
+    if (!(error instanceof ValidationError)) {
+        throw error;
+    }
+}
+try {
+    post2.email = "google.com"; // should not pass
+    throw new Error("Assignment should not pass");
+} catch (error) {
+    if (!(error instanceof ValidationError)) {
+        throw error;
+    }
+}
+try {
+    post2.site = "googlecom"; // should not pass
+    throw new Error("Assignment should not pass");
+} catch (error) {
+    if (!(error instanceof ValidationError)) {
+        throw error;
+    }
+}

--- a/sample/sample8-automatic-validation/app.ts
+++ b/sample/sample8-automatic-validation/app.ts
@@ -95,3 +95,20 @@ Object.assign(post3, {
 });
 
 console.log("Created post3 successfully");
+
+
+let post4 = new Post();
+try {
+    // Should fail on the first attempted property assignment
+    Object.assign(post4, {
+        title: "Hello",
+        text: "this is a great post about hell world",
+        rating: 1.1,
+        email: "google.com",
+        site: "googlecom",
+        createDate: undefined,
+        tags: ["JS"]
+    });
+} catch (error) {
+    console.log("Post 4 successfully got validation errors", error);
+}

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -124,8 +124,6 @@ export function AutoValidate() {
                 propertyValidatorMap[propertyName].push(validationMetadata);
             }
 
-            targetClass.prototype.__validatedProperties = {};
-
             /**
              * For each property which holds a validator annotation, define custom
              * setter and getter, and store it in a private data store
@@ -135,6 +133,10 @@ export function AutoValidate() {
 
                 Object.defineProperty(targetClass.prototype, property, {
                     set: function (val) {
+                        if (this.__validatedProperties === undefined) {
+                            this.__validatedProperties = {};
+                        }
+
                         const errors = validators.map(validatorMetadata => {
                             let isValid: boolean;
 
@@ -187,6 +189,9 @@ export function AutoValidate() {
                         return val;
                     },
                     get: function () {
+                        if (this.__validatedProperties === undefined) {
+                            this.__validatedProperties = {};
+                        }
                         return this.__validatedProperties[property];
                     }
                 });

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -174,6 +174,7 @@ export function AutoValidate() {
                             error.target = this;
                             error.property = property;
                             error.constraints = {};
+                            error.children = [];
 
                             for (const [type, messageString] of errors) {
                                 error.constraints[type] = messageString;

--- a/src/metadata/ValidationMetadataArgs.ts
+++ b/src/metadata/ValidationMetadataArgs.ts
@@ -18,7 +18,7 @@ export interface ValidationMetadataArgs {
     /**
      * Property of the object to be validated.
      */
-    propertyName: string;
+    propertyName?: string;
 
     /**
      * Constraint class that performs validation. Used only for custom validations.

--- a/test/functional/automatic-validation.spec.ts
+++ b/test/functional/automatic-validation.spec.ts
@@ -1,0 +1,80 @@
+import "es6-shim";
+import {
+    ArrayNotEmpty, ArrayMinSize, ArrayMaxSize, MaxLength, MinLength, AutoValidate
+} from "../../src/decorator/decorators";
+import { Validator } from "../../src/validation/Validator";
+import { expect } from "chai";
+
+import { should, use } from "chai";
+
+import * as chaiAsPromised from "chai-as-promised";
+
+should();
+use(chaiAsPromised);
+
+// -------------------------------------------------------------------------
+// Setup
+// -------------------------------------------------------------------------
+
+describe("Automatic validation", function () {
+
+    @AutoValidate()
+    class TestClass {
+        @MinLength(10)
+        @MaxLength(20)
+        public title: string;
+
+        @ArrayNotEmpty()
+        @ArrayMinSize(2)
+        @ArrayMaxSize(5)
+        @MinLength(3, { each: true, message: "Tag is too short. Minimal length is $value characters" })
+        @MaxLength(50, { each: true, message: "Tag is too long. Maximal length is $value characters" })
+        tags: string[];
+
+    }
+
+    it("should assign property ", function () {
+        const testInstance = new TestClass();
+
+        testInstance.title = "This is a title";
+
+        testInstance.title.should.equal("This is a title");
+    });
+
+    it("should assign array property ", function () {
+        const testInstance = new TestClass();
+        const tags = ["FirstAwesomeTag", "EvenBetterTag"];
+        testInstance.tags = tags;
+
+        testInstance.tags.should.equal(tags);
+    });
+
+    it("should correctly fail property assignment ", function () {
+        const testInstance = new TestClass();
+
+        let errorText;
+        try {
+            testInstance.title = "Too Short";
+        } catch (e) {
+            errorText = e.toString();
+        }
+
+        errorText.should.be.equal("An instance of TestClass has failed the validation:\n" +
+        " - property title has failed the following constraints: minLength \n");
+    });
+
+    it("should correctly fail array property assignment ", function () {
+        const testInstance = new TestClass();
+
+        let errorText;
+        try {
+            testInstance.tags = ["JS"];
+        } catch (e) {
+            errorText = e.toString();
+        }
+
+        errorText.should.be.equal("An instance of TestClass has failed the validation:\n" +
+        " - property tags has failed the following constraints: minLength, arrayMinSize \n");
+    });
+
+});

--- a/test/functional/automatic-validation.spec.ts
+++ b/test/functional/automatic-validation.spec.ts
@@ -76,5 +76,4 @@ describe("Automatic validation", function () {
         errorText.should.be.equal("An instance of TestClass has failed the validation:\n" +
         " - property tags has failed the following constraints: minLength, arrayMinSize \n");
     });
-
 });


### PR DESCRIPTION
Hi,

While I really like the annotation approach to further specify the possible values of variables in classes, much like a range of other classes.

We were considering including the class validator library in some projects, where there are a wide range of different DTOs we would like to verify.

In that connection, it felt rather bloated to have to manually invoke the validation every time a new object is created, as such it occurred to me that it would, at least for our use case, be possible to do all the validation entirely behind the scenes.

I know that there are edge cases, such as if a property is never assigned, and left as undefined, this wont be caught automatically -- but I recon that many like my use case is able to guarantee assignment to all relevant fields.

While I am not that deep into the codebase of the project, I have attempted to implement the automatic validation via property setters, along with adding an extra annotation which should target the class containing the properties with validator annotations attached!

Please let me know if you have any input.