### PR TITLE
fix: apply custom constraint class validation to each item in the array

### DIFF
--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -1,14 +1,14 @@
-import { Validator } from "./Validator";
-import { ValidationError } from "./ValidationError";
-import { ValidationMetadata } from "../metadata/ValidationMetadata";
-import { MetadataStorage } from "../metadata/MetadataStorage";
-import { getFromContainer } from "../container";
-import { ValidatorOptions } from "./ValidatorOptions";
-import { ValidationTypes } from "./ValidationTypes";
-import { ConstraintMetadata } from "../metadata/ConstraintMetadata";
-import { ValidationArguments } from "./ValidationArguments";
-import { ValidationUtils } from "./ValidationUtils";
-import { isPromise } from "../utils";
+import {Validator} from "./Validator";
+import {ValidationError} from "./ValidationError";
+import {ValidationMetadata} from "../metadata/ValidationMetadata";
+import {MetadataStorage} from "../metadata/MetadataStorage";
+import {getFromContainer} from "../container";
+import {ValidatorOptions} from "./ValidatorOptions";
+import {ValidationTypes} from "./ValidationTypes";
+import {ConstraintMetadata} from "../metadata/ConstraintMetadata";
+import {ValidationArguments} from "./ValidationArguments";
+import {ValidationUtils} from "./ValidationUtils";
+import {isPromise} from "../utils";
 
 /**
  * Executes validation over given object.
@@ -33,7 +33,7 @@ export class ValidationExecutor {
     // -------------------------------------------------------------------------
 
     constructor(private validator: Validator,
-        private validatorOptions?: ValidatorOptions) {
+                private validatorOptions?: ValidatorOptions) {
     }
 
     // -------------------------------------------------------------------------
@@ -82,7 +82,7 @@ export class ValidationExecutor {
             const value = (object as any)[propertyName];
             const definedMetadatas = groupedMetadatas[propertyName].filter(metadata => metadata.type === ValidationTypes.IS_DEFINED);
             const metadatas = groupedMetadatas[propertyName].filter(
-                metadata => metadata.type !== ValidationTypes.IS_DEFINED && metadata.type !== ValidationTypes.WHITELIST);
+              metadata => metadata.type !== ValidationTypes.IS_DEFINED && metadata.type !== ValidationTypes.WHITELIST);
 
             if (value instanceof Promise && metadatas.find(metadata => metadata.type === ValidationTypes.PROMISE_VALIDATION)) {
                 this.awaitingPromises.push(value.then((resolvedValue) => {
@@ -95,8 +95,8 @@ export class ValidationExecutor {
     }
 
     whitelist(object: any,
-        groupedMetadatas: { [propertyName: string]: ValidationMetadata[] },
-        validationErrors: ValidationError[]) {
+              groupedMetadatas: { [propertyName: string]: ValidationMetadata[] },
+              validationErrors: ValidationError[]) {
         let notAllowedProperties: string[] = [];
 
         Object.keys(object).forEach(propertyName => {
@@ -149,10 +149,10 @@ export class ValidationExecutor {
     // -------------------------------------------------------------------------
 
     private performValidations(object: any,
-        value: any, propertyName: string,
-        definedMetadatas: ValidationMetadata[],
-        metadatas: ValidationMetadata[],
-        validationErrors: ValidationError[]) {
+                               value: any, propertyName: string,
+                               definedMetadatas: ValidationMetadata[],
+                               metadatas: ValidationMetadata[],
+                               validationErrors: ValidationError[]) {
 
         const customValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CUSTOM_VALIDATION);
         const nestedValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.NESTED_VALIDATION);
@@ -211,17 +211,17 @@ export class ValidationExecutor {
     }
 
     private conditionalValidations(object: Object,
-        value: any,
-        metadatas: ValidationMetadata[]) {
+                                   value: any,
+                                   metadatas: ValidationMetadata[]) {
         return metadatas
             .map(metadata => metadata.constraints[0](object, value))
             .reduce((resultA, resultB) => resultA && resultB, true);
     }
 
     private defaultValidations(object: Object,
-        value: any,
-        metadatas: ValidationMetadata[],
-        errorMap: { [key: string]: string }) {
+                               value: any,
+                               metadatas: ValidationMetadata[],
+                               errorMap: { [key: string]: string }) {
         return metadatas
             .filter(metadata => {
                 if (metadata.each) {
@@ -383,9 +383,9 @@ export class ValidationExecutor {
     }
 
     private mapContexts(object: Object,
-        value: any,
-        metadatas: ValidationMetadata[],
-        error: ValidationError) {
+                        value: any,
+                        metadatas: ValidationMetadata[],
+                        error: ValidationError) {
 
         return metadatas
             .forEach(metadata => {
@@ -404,9 +404,9 @@ export class ValidationExecutor {
     }
 
     private createValidationError(object: Object,
-        value: any,
-        metadata: ValidationMetadata,
-        customValidatorMetadata?: ConstraintMetadata): [string, string] {
+                                  value: any,
+                                  metadata: ValidationMetadata,
+                                  customValidatorMetadata?: ConstraintMetadata): [string, string] {
 
         const targetName = object.constructor ? (object.constructor as any).name : undefined;
         const type = this.getConstraintType(metadata, customValidatorMetadata);

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -148,11 +148,11 @@ export class ValidationExecutor {
     // Private Methods
     // -------------------------------------------------------------------------
 
-    private performValidations(object: any,
-                               value: any, propertyName: string,
-                               definedMetadatas: ValidationMetadata[],
-                               metadatas: ValidationMetadata[],
-                               validationErrors: ValidationError[]) {
+    private performValidations (object: any,
+                                value: any, propertyName: string,
+                                definedMetadatas: ValidationMetadata[],
+                                metadatas: ValidationMetadata[],
+                                validationErrors: ValidationError[]) {
 
         const customValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CUSTOM_VALIDATION);
         const nestedValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.NESTED_VALIDATION);
@@ -240,9 +240,9 @@ export class ValidationExecutor {
     }
 
     private customValidations(object: Object,
-        value: any,
-        metadatas: ValidationMetadata[],
-        errorMap: { [key: string]: string }) {
+                              value: any,
+                              metadatas: ValidationMetadata[],
+                              errorMap: { [key: string]: string }) {
 
         metadatas.forEach(metadata => {
             getFromContainer(MetadataStorage)

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -1,14 +1,14 @@
-import {Validator} from "./Validator";
-import {ValidationError} from "./ValidationError";
-import {ValidationMetadata} from "../metadata/ValidationMetadata";
-import {MetadataStorage} from "../metadata/MetadataStorage";
-import {getFromContainer} from "../container";
-import {ValidatorOptions} from "./ValidatorOptions";
-import {ValidationTypes} from "./ValidationTypes";
-import {ConstraintMetadata} from "../metadata/ConstraintMetadata";
-import {ValidationArguments} from "./ValidationArguments";
-import {ValidationUtils} from "./ValidationUtils";
-import {isPromise} from "../utils";
+import { Validator } from "./Validator";
+import { ValidationError } from "./ValidationError";
+import { ValidationMetadata } from "../metadata/ValidationMetadata";
+import { MetadataStorage } from "../metadata/MetadataStorage";
+import { getFromContainer } from "../container";
+import { ValidatorOptions } from "./ValidatorOptions";
+import { ValidationTypes } from "./ValidationTypes";
+import { ConstraintMetadata } from "../metadata/ConstraintMetadata";
+import { ValidationArguments } from "./ValidationArguments";
+import { ValidationUtils } from "./ValidationUtils";
+import { isPromise } from "../utils";
 
 /**
  * Executes validation over given object.
@@ -33,7 +33,7 @@ export class ValidationExecutor {
     // -------------------------------------------------------------------------
 
     constructor(private validator: Validator,
-                private validatorOptions?: ValidatorOptions) {
+        private validatorOptions?: ValidatorOptions) {
     }
 
     // -------------------------------------------------------------------------
@@ -82,7 +82,7 @@ export class ValidationExecutor {
             const value = (object as any)[propertyName];
             const definedMetadatas = groupedMetadatas[propertyName].filter(metadata => metadata.type === ValidationTypes.IS_DEFINED);
             const metadatas = groupedMetadatas[propertyName].filter(
-              metadata => metadata.type !== ValidationTypes.IS_DEFINED && metadata.type !== ValidationTypes.WHITELIST);
+                metadata => metadata.type !== ValidationTypes.IS_DEFINED && metadata.type !== ValidationTypes.WHITELIST);
 
             if (value instanceof Promise && metadatas.find(metadata => metadata.type === ValidationTypes.PROMISE_VALIDATION)) {
                 this.awaitingPromises.push(value.then((resolvedValue) => {
@@ -95,8 +95,8 @@ export class ValidationExecutor {
     }
 
     whitelist(object: any,
-              groupedMetadatas: { [propertyName: string]: ValidationMetadata[] },
-              validationErrors: ValidationError[]) {
+        groupedMetadatas: { [propertyName: string]: ValidationMetadata[] },
+        validationErrors: ValidationError[]) {
         let notAllowedProperties: string[] = [];
 
         Object.keys(object).forEach(propertyName => {
@@ -148,11 +148,11 @@ export class ValidationExecutor {
     // Private Methods
     // -------------------------------------------------------------------------
 
-    private performValidations (object: any,
-                                value: any, propertyName: string,
-                                definedMetadatas: ValidationMetadata[],
-                                metadatas: ValidationMetadata[],
-                                validationErrors: ValidationError[]) {
+    private performValidations(object: any,
+        value: any, propertyName: string,
+        definedMetadatas: ValidationMetadata[],
+        metadatas: ValidationMetadata[],
+        validationErrors: ValidationError[]) {
 
         const customValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CUSTOM_VALIDATION);
         const nestedValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.NESTED_VALIDATION);
@@ -211,17 +211,17 @@ export class ValidationExecutor {
     }
 
     private conditionalValidations(object: Object,
-                                   value: any,
-                                   metadatas: ValidationMetadata[]) {
+        value: any,
+        metadatas: ValidationMetadata[]) {
         return metadatas
             .map(metadata => metadata.constraints[0](object, value))
             .reduce((resultA, resultB) => resultA && resultB, true);
     }
 
     private defaultValidations(object: Object,
-                               value: any,
-                               metadatas: ValidationMetadata[],
-                               errorMap: { [key: string]: string }) {
+        value: any,
+        metadatas: ValidationMetadata[],
+        errorMap: { [key: string]: string }) {
         return metadatas
             .filter(metadata => {
                 if (metadata.each) {
@@ -240,9 +240,9 @@ export class ValidationExecutor {
     }
 
     private customValidations(object: Object,
-                              value: any,
-                              metadatas: ValidationMetadata[],
-                              errorMap: { [key: string]: string }) {
+        value: any,
+        metadatas: ValidationMetadata[],
+        errorMap: { [key: string]: string }) {
 
         metadatas.forEach(metadata => {
             getFromContainer(MetadataStorage)
@@ -258,20 +258,54 @@ export class ValidationExecutor {
                         value: value,
                         constraints: metadata.constraints
                     };
-                    const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments);
-                    if (isPromise(validatedValue)) {
-                        const promise = validatedValue.then(isValid => {
-                            if (!isValid) {
+
+                    if (!metadata.each || !(value instanceof Array)) {
+                        const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments);
+                        if (isPromise(validatedValue)) {
+                            const promise = validatedValue.then(isValid => {
+                                if (!isValid) {
+                                    const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
+                                    errorMap[type] = message;
+                                }
+                            });
+                            this.awaitingPromises.push(promise);
+                        } else {
+                            if (!validatedValue) {
                                 const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
                                 errorMap[type] = message;
                             }
-                        });
-                        this.awaitingPromises.push(promise);
-                    } else {
-                        if (!validatedValue) {
-                            const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
-                            errorMap[type] = message;
                         }
+
+                        return;
+                    }
+
+                    // Validation needs to be applied to each array item
+                    const validatedSubValues = value.map((subValue: any) => customConstraintMetadata.instance.validate(subValue, validationArguments));
+                    const validationIsAsync = validatedSubValues
+                        .some((validatedSubValue: boolean | Promise<boolean>) => isPromise(validatedSubValue));
+
+                    if (validationIsAsync) {
+                        // Wrap plain values (if any) in promises, so that all are async
+                        const asyncValidatedSubValues = validatedSubValues
+                            .map((validatedSubValue: boolean | Promise<boolean>) => isPromise(validatedSubValue) ? validatedSubValue : Promise.resolve(validatedSubValue));
+                        const asyncValidationIsFinishedPromise = Promise.all(asyncValidatedSubValues)
+                            .then((flatValidatedValues: boolean[]) => {
+                                const validationResult = flatValidatedValues.every((isValid: boolean) => isValid);
+                                if (!validationResult) {
+                                    const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
+                                    errorMap[type] = message;
+                                }
+                            });
+
+                        this.awaitingPromises.push(asyncValidationIsFinishedPromise);
+
+                        return;
+                    }
+
+                    const validationResult = validatedSubValues.every((isValid: boolean) => isValid);
+                    if (!validationResult) {
+                        const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
+                        errorMap[type] = message;
                     }
                 });
         });
@@ -349,9 +383,9 @@ export class ValidationExecutor {
     }
 
     private mapContexts(object: Object,
-                        value: any,
-                        metadatas: ValidationMetadata[],
-                        error: ValidationError) {
+        value: any,
+        metadatas: ValidationMetadata[],
+        error: ValidationError) {
 
         return metadatas
             .forEach(metadata => {
@@ -370,9 +404,9 @@ export class ValidationExecutor {
     }
 
     private createValidationError(object: Object,
-                                  value: any,
-                                  metadata: ValidationMetadata,
-                                  customValidatorMetadata?: ConstraintMetadata): [string, string] {
+        value: any,
+        metadata: ValidationMetadata,
+        customValidatorMetadata?: ConstraintMetadata): [string, string] {
 
         const targetName = object.constructor ? (object.constructor as any).name : undefined;
         const type = this.getConstraintType(metadata, customValidatorMetadata);

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1,9 +1,9 @@
 import "es6-shim";
-import { Contains, Matches, MinLength, ValidateNested, ValidatorConstraint, Validate } from "../../src/decorator/decorators";
-import { Validator } from "../../src/validation/Validator";
-import { ValidationError, ValidatorConstraintInterface } from "../../src";
+import {Contains, Matches, MinLength, ValidateNested, ValidatorConstraint, Validate } from "../../src/decorator/decorators";
+import {Validator} from "../../src/validation/Validator";
+import {ValidationError, ValidatorConstraintInterface} from "../../src";
 
-import { should, use } from "chai";
+import {should, use} from "chai";
 
 import * as chaiAsPromised from "chai-as-promised";
 
@@ -20,11 +20,11 @@ const validator = new Validator();
 // Specifications: common decorators
 // -------------------------------------------------------------------------
 
-describe("validation options", function () {
+describe("validation options", function() {
 
-    describe("message", function () {
+    describe("message", function() {
 
-        it("should contain a custom message", function () {
+        it("should contain a custom message", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "String is not valid. You string must contain a hello word"
@@ -40,7 +40,7 @@ describe("validation options", function () {
             });
         });
 
-        it("$value token should be replaced in a custom message", function () {
+        it("$value token should be replaced in a custom message", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "$value is not valid. You string must contain a hello word"
@@ -56,7 +56,7 @@ describe("validation options", function () {
             });
         });
 
-        it("$value token should be replaced in a custom message", function () {
+        it("$value token should be replaced in a custom message", function() {
             class MyClass {
                 @MinLength(2, {
                     message: args => {
@@ -76,7 +76,7 @@ describe("validation options", function () {
             });
         });
 
-        it("$constraint1 token should be replaced in a custom message", function () {
+        it("$constraint1 token should be replaced in a custom message", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "String is not valid. You string must contain a $constraint1 word"
@@ -92,7 +92,7 @@ describe("validation options", function () {
             });
         });
 
-        it("$target token should be replaced in a custom message", function () {
+        it("$target token should be replaced in a custom message", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "$target is not valid."
@@ -108,7 +108,7 @@ describe("validation options", function () {
             });
         });
 
-        it("$property token should be replaced in a custom message", function () {
+        it("$property token should be replaced in a custom message", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "$property is not valid."
@@ -124,7 +124,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should replace all token", function () {
+        it("should replace all token", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "$target#$property is not valid: $value must contain a $constraint1 word"
@@ -142,9 +142,9 @@ describe("validation options", function () {
 
     });
 
-    describe("each", function () {
+    describe("each", function() {
 
-        it("should apply validation to each item in the array", function () {
+        it("should apply validation to each item in the array", function() {
             class MyClass {
                 @Contains("hello", {
                     each: true
@@ -163,7 +163,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should apply validation via custom constraint class to array items (but not array itself)", function () {
+        it("should apply validation via custom constraint class to array items (but not array itself)", function() {
             @ValidatorConstraint({ name: "customIsNotArrayConstraint", async: false })
             class CustomIsNotArrayConstraint implements ValidatorConstraintInterface {
                 validate(value: any) {
@@ -185,7 +185,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should apply validation via custom constraint class with synchronous logic to each item in the array", function () {
+        it("should apply validation via custom constraint class with synchronous logic to each item in the array", function() {
             @ValidatorConstraint({ name: "customContainsHelloConstraint", async: false })
             class CustomContainsHelloConstraint implements ValidatorConstraintInterface {
                 validate(value: any) {
@@ -211,7 +211,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should apply validation via custom constraint class with async logic to each item in the array", function () {
+        it("should apply validation via custom constraint class with async logic to each item in the array", function() {
             @ValidatorConstraint({ name: "customAsyncContainsHelloConstraint", async: true })
             class CustomAsyncContainsHelloConstraint implements ValidatorConstraintInterface {
                 validate(value: any) {
@@ -239,7 +239,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should apply validation via custom constraint class with mixed (synchronous + async) logic to each item in the array", function () {
+        it("should apply validation via custom constraint class with mixed (synchronous + async) logic to each item in the array", function() {
             @ValidatorConstraint({ name: "customMixedContainsHelloConstraint", async: true })
             class CustomMixedContainsHelloConstraint implements ValidatorConstraintInterface {
                 validate(value: any) {
@@ -269,7 +269,7 @@ describe("validation options", function () {
 
     });
 
-    describe("groups", function () {
+    describe("groups", function() {
         function expectTitleContains(error: ValidationError) {
             error.constraints.should.eql({ contains: "title must contain a hello string" });
         }
@@ -306,27 +306,27 @@ describe("validation options", function () {
         validNone.title = "bye world";
         validNone.text = "hello world";
 
-        describe("should validate only properties of the given group: title-validation", function () {
-            it("with valid title", function () {
+        describe("should validate only properties of the given group: title-validation", function() {
+            it("with valid title", function() {
                 return validator.validate(validTitle, { groups: ["title-validation"] }).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with valid text", function () {
+            it("with valid text", function() {
                 return validator.validate(validText, { groups: ["title-validation"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTitleContains(errors[0]);
                 });
             });
 
-            it("with both valid", function () {
+            it("with both valid", function() {
                 return validator.validate(validBoth, { groups: ["title-validation"] }).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with none valid", function () {
+            it("with none valid", function() {
                 return validator.validate(validNone, { groups: ["title-validation"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTitleContains(errors[0]);
@@ -335,27 +335,27 @@ describe("validation options", function () {
 
         });
 
-        describe("should validate only properties of the given group: text-validation", function () {
-            it("with valid title", function () {
+        describe("should validate only properties of the given group: text-validation", function() {
+            it("with valid title", function() {
                 return validator.validate(validTitle, { groups: ["text-validation"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTextContains(errors[0]);
                 });
             });
 
-            it("with valid text", function () {
+            it("with valid text", function() {
                 return validator.validate(validText, { groups: ["text-validation"] }).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with both valid", function () {
+            it("with both valid", function() {
                 return validator.validate(validBoth, { groups: ["text-validation"] }).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with none valid", function () {
+            it("with none valid", function() {
                 return validator.validate(validNone, { groups: ["text-validation"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTextContains(errors[0]);
@@ -364,28 +364,28 @@ describe("validation options", function () {
 
         });
 
-        describe("should validate only properties of the given groups: both groups", function () {
-            it("with valid title", function () {
+        describe("should validate only properties of the given groups: both groups", function() {
+            it("with valid title", function() {
                 return validator.validate(validTitle, { groups: ["title-validation", "text-validation"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTextContains(errors[0]);
                 });
             });
 
-            it("with valid text", function () {
+            it("with valid text", function() {
                 return validator.validate(validText, { groups: ["title-validation", "text-validation"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTitleContains(errors[0]);
                 });
             });
 
-            it("with both valid", function () {
+            it("with both valid", function() {
                 return validator.validate(validBoth, { groups: ["title-validation", "text-validation"] }).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with none valid", function () {
+            it("with none valid", function() {
                 return validator.validate(validNone, { groups: ["title-validation", "text-validation"] }).then(errors => {
                     errors.length.should.be.equal(2);
                     expectTitleContains(errors[0]);
@@ -394,28 +394,28 @@ describe("validation options", function () {
             });
         });
 
-        describe("should validate all if no group is given", function () {
-            it("with valid title", function () { // todo: all or without? what is better expected behaviour?
+        describe("should validate all if no group is given", function() {
+            it("with valid title", function() { // todo: all or without? what is better expected behaviour?
                 return validator.validate(validTitle).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTextContains(errors[0]);
                 });
             });
 
-            it("with valid text", function () { // todo: all or without? what is better expected behaviour?
+            it("with valid text", function() { // todo: all or without? what is better expected behaviour?
                 return validator.validate(validText).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTitleContains(errors[0]);
                 });
             });
 
-            it("with both valid", function () { // todo: all or without? what is better expected behaviour?
+            it("with both valid", function() { // todo: all or without? what is better expected behaviour?
                 return validator.validate(validBoth).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with none valid", function () { // todo: all or without? what is better expected behaviour?
+            it("with none valid", function() { // todo: all or without? what is better expected behaviour?
                 return validator.validate(validNone).then(errors => {
                     errors.length.should.be.equal(2);
                     expectTitleContains(errors[0]);
@@ -425,28 +425,28 @@ describe("validation options", function () {
 
         });
 
-        describe("should validate all groups if empty group array is given", function () {
-            it("with valid title", function () {
+        describe("should validate all groups if empty group array is given", function() {
+            it("with valid title", function() {
                 return validator.validate(validTitle, { groups: [] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTextContains(errors[0]);
                 });
             });
 
-            it("with valid text", function () {
+            it("with valid text", function() {
                 return validator.validate(validText, { groups: [] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTitleContains(errors[0]);
                 });
             });
 
-            it("with both valid", function () {
+            it("with both valid", function() {
                 return validator.validate(validBoth, { groups: [] }).then(errors => {
                     errors.length.should.be.equal(0);
                 });
             });
 
-            it("with none valid", function () {
+            it("with none valid", function() {
                 return validator.validate(validNone, { groups: [] }).then(errors => {
                     errors.length.should.be.equal(2);
                     expectTitleContains(errors[0]);
@@ -455,7 +455,7 @@ describe("validation options", function () {
             });
         });
 
-        describe("multiple groups per property", function () {
+        describe("multiple groups per property", function() {
             class MyClass {
                 @Contains("hello", { groups: ["contains"] })
                 @Matches(/.*stranger.*/, { groups: ["matches"] })
@@ -478,27 +478,27 @@ describe("validation options", function () {
             const validNone = new MyClass();
             validNone.title = "howdy rowdy";
 
-            describe("group: contains", function () {
-                it("with valid contains", function () {
+            describe("group: contains", function() {
+                it("with valid contains", function() {
                     return validator.validate(validContains, { groups: ["contains"] }).then(errors => {
                         errors.length.should.be.equal(0);
                     });
                 });
 
-                it("with valid matches", function () {
+                it("with valid matches", function() {
                     return validator.validate(validMatches, { groups: ["contains"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         expectTitleContains(errors[0]);
                     });
                 });
 
-                it("with valid both", function () {
+                it("with valid both", function() {
                     return validator.validate(validBoth, { groups: ["contains"] }).then(errors => {
                         errors.length.should.be.equal(0);
                     });
                 });
 
-                it("with valid none", function () {
+                it("with valid none", function() {
                     return validator.validate(validNone, { groups: ["contains"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         expectTitleContains(errors[0]);
@@ -507,28 +507,28 @@ describe("validation options", function () {
 
             });
 
-            describe("group: matches", function () {
+            describe("group: matches", function() {
 
-                it("with valid contains", function () {
+                it("with valid contains", function() {
                     return validator.validate(validContains, { groups: ["matches"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         expectTitleMatches(errors[0]);
                     });
                 });
 
-                it("with valid matches", function () {
+                it("with valid matches", function() {
                     return validator.validate(validMatches, { groups: ["matches"] }).then(errors => {
                         errors.length.should.be.equal(0);
                     });
                 });
 
-                it("with valid both", function () {
+                it("with valid both", function() {
                     return validator.validate(validBoth, { groups: ["matches"] }).then(errors => {
                         errors.length.should.be.equal(0);
                     });
                 });
 
-                it("with valid none", function () {
+                it("with valid none", function() {
                     return validator.validate(validNone, { groups: ["matches"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         expectTitleMatches(errors[0]);
@@ -537,28 +537,28 @@ describe("validation options", function () {
 
             });
 
-            describe("groups: contains & matches", function () {
-                it("with valid contains", function () {
+            describe("groups: contains & matches", function() {
+                it("with valid contains", function() {
                     return validator.validate(validContains, { groups: ["contains", "matches"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         expectTitleMatches(errors[0]);
                     });
                 });
 
-                it("with valid matches", function () {
+                it("with valid matches", function() {
                     return validator.validate(validMatches, { groups: ["contains", "matches"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         expectTitleContains(errors[0]);
                     });
                 });
 
-                it("with valid both", function () {
+                it("with valid both", function() {
                     return validator.validate(validBoth, { groups: ["contains", "matches"] }).then(errors => {
                         errors.length.should.be.equal(0);
                     });
                 });
 
-                it("with valid none", function () {
+                it("with valid none", function() {
                     return validator.validate(validNone, { groups: ["contains", "matches"] }).then(errors => {
                         errors.length.should.be.equal(1);
                         errors[0].constraints.should.be.eql({
@@ -572,7 +572,7 @@ describe("validation options", function () {
 
         });
 
-        describe("always", function () {
+        describe("always", function() {
 
             class MyClass {
                 @Contains("hello", {
@@ -589,7 +589,7 @@ describe("validation options", function () {
 
             const model = new MyClass();
 
-            it("should always validate a marked field even if another group is specified", function () {
+            it("should always validate a marked field even if another group is specified", function() {
                 return validator.validate(model, { groups: ["sometimes"] }).then(errors => {
                     errors.length.should.be.equal(2);
                     expectTitleContains(errors[0]);
@@ -597,14 +597,14 @@ describe("validation options", function () {
                 });
             });
 
-            it("should always validate a marked field if its group is specified also (doubly enabled)", function () {
+            it("should always validate a marked field if its group is specified also (doubly enabled)", function() {
                 return validator.validate(model, { groups: ["always"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectTextContains(errors[0]);
                 });
             });
 
-            it("should always validate *all* fields if group is not specified", function () {
+            it("should always validate *all* fields if group is not specified", function() {
                 return validator.validate(model, { groups: undefined }).then(errors => {
                     errors.length.should.be.equal(2);
                     expectTitleContains(errors[0]);
@@ -612,7 +612,7 @@ describe("validation options", function () {
                 });
             });
 
-            it("should always validate *all* fields if groups array is empty", function () {
+            it("should always validate *all* fields if groups array is empty", function() {
                 return validator.validate(model, { groups: [] }).then(errors => {
                     errors.length.should.be.equal(2);
                     expectTitleContains(errors[0]);
@@ -622,7 +622,7 @@ describe("validation options", function () {
 
         });
 
-        describe("groups - nested", function () {
+        describe("groups - nested", function() {
             class Nested {
                 @Contains("hello", {
                     groups: ["always"],
@@ -651,7 +651,7 @@ describe("validation options", function () {
                 error.children[0].constraints.should.eql({ contains: "text must contain a hello string" });
             }
 
-            it("should validate all children if no group is given", function () {
+            it("should validate all children if no group is given", function() {
                 return validator.validate(model, { groups: undefined }).then(errors => {
                     errors.length.should.be.equal(3);
                     expectChildConstraint(errors[0], "always");
@@ -660,7 +660,7 @@ describe("validation options", function () {
                 });
             });
 
-            it("should validate only the given group + always", function () {
+            it("should validate only the given group + always", function() {
                 return validator.validate(model, { groups: ["sometimes"] }).then(errors => {
                     errors.length.should.be.equal(2);
                     expectChildConstraint(errors[0], "always");
@@ -668,7 +668,7 @@ describe("validation options", function () {
                 });
             });
 
-            it("should validate only the given group + always", function () {
+            it("should validate only the given group + always", function() {
                 return validator.validate(model, { groups: ["always"] }).then(errors => {
                     errors.length.should.be.equal(1);
                     expectChildConstraint(errors[0], "always");
@@ -677,9 +677,9 @@ describe("validation options", function () {
         });
     });
 
-    describe("context", function () {
+    describe("context", function() {
 
-        it("should map context", function () {
+        it("should map context", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "String is not valid. You string must contain a hello word",
@@ -707,7 +707,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should map multiple context on a single property for different constraints", function () {
+        it("should map multiple context on a single property for different constraints", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "String is not valid. You string must contain a hello word",
@@ -732,7 +732,7 @@ describe("validation options", function () {
             });
         });
 
-        it("should not map no context", function () {
+        it("should not map no context", function() {
             class MyClass {
                 @Contains("hello", {
                     message: "String is not valid. You string must contain a hello word"

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -175,11 +175,11 @@ describe("validation options", function() {
                 @Validate(CustomIsNotArrayConstraint, {
                     each: true
                 })
-                someNotArrayProperty: string[];
+                someArrayOfNonArrayItems: string[];
             }
 
             const model = new MyClass();
-            model.someNotArrayProperty = ["not array", "also not array", "not array at all"];
+            model.someArrayOfNonArrayItems = ["not array", "also not array", "not array at all"];
             return validator.validate(model).then(errors => {
                 errors.length.should.be.equal(0);
             });


### PR DESCRIPTION
When `@Validate` + some custom constraint class is used with `{ each: true }`, then it is expected to be applied to each item of the target object field:
https://github.com/typestack/class-validator/issues/260
