### PR TITLE
Pass context for isDefined and custom validators

### DIFF
--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -168,6 +168,7 @@ export class ValidationExecutor {
 
         // handle IS_DEFINED validation type the special way - it should work no matter skipMissingProperties is set or not
         this.defaultValidations(object, value, definedMetadatas, validationError.constraints);
+        this.mapContexts(object, value, definedMetadatas, validationError);
 
         if ((value === null || value === undefined) && this.validatorOptions && this.validatorOptions.skipMissingProperties === true) {
             return;
@@ -178,6 +179,7 @@ export class ValidationExecutor {
         this.nestedValidations(value, nestedValidationMetadatas, validationError.children);
 
         this.mapContexts(object, value, metadatas, validationError);
+        this.mapContexts(object, value, customValidationMetadatas, validationError);
     }
 
     private generateValidationError(object: Object, value: any, propertyName: string) {

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -350,7 +350,13 @@ export class ValidationExecutor {
         return metadatas
             .forEach(metadata => {
                 if (metadata.context) {
-                    const type = this.getConstraintType(metadata);
+                    let customConstraint;
+                    if (metadata.type === ValidationTypes.CUSTOM_VALIDATION) {
+                        const customConstraints = this.metadataStorage.getTargetValidatorConstraints(metadata.constraintCls);
+                        customConstraint = customConstraints[0];
+                    }
+
+                    const type = this.getConstraintType(metadata, customConstraint);
 
                     if (error.constraints[type]) {
                         if (!error.contexts) {

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -175,7 +175,7 @@ export class ValidationExecutor {
         }
 
         this.defaultValidations(object, value, metadatas, validationError.constraints);
-        this.customValidations(object, value, customValidationMetadatas, validationError.constraints);
+        this.customValidations(object, value, customValidationMetadatas, validationError);
         this.nestedValidations(value, nestedValidationMetadatas, validationError.children);
 
         this.mapContexts(object, value, metadatas, validationError);
@@ -236,7 +236,7 @@ export class ValidationExecutor {
     private customValidations(object: Object,
                               value: any,
                               metadatas: ValidationMetadata[],
-                              errorMap: { [key: string]: string }) {
+                              error: ValidationError) {
 
         metadatas.forEach(metadata => {
             getFromContainer(MetadataStorage)
@@ -257,14 +257,20 @@ export class ValidationExecutor {
                         const promise = validatedValue.then(isValid => {
                             if (!isValid) {
                                 const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
-                                errorMap[type] = message;
+                                error.constraints[type] = message;
+                                if (metadata.context) {
+                                    if (!error.contexts) {
+                                        error.contexts = {};
+                                    }
+                                    error.contexts[type] = Object.assign((error.contexts[type] || {}), metadata.context);
+                                }
                             }
                         });
                         this.awaitingPromises.push(promise);
                     } else {
                         if (!validatedValue) {
                             const [type, message] = this.createValidationError(object, value, metadata, customConstraintMetadata);
-                            errorMap[type] = message;
+                            error.constraints[type] = message;
                         }
                     }
                 });

--- a/test/functional/custom-decorators.spec.ts
+++ b/test/functional/custom-decorators.spec.ts
@@ -53,6 +53,7 @@ describe("custom decorators", function() {
         
         class MyClass {
             @IsLongerThan("lastName", {
+                context: { foo: "bar" },
                 message: "$property must be longer then $constraint1. Given value: $value"
             })
             firstName: string;
@@ -85,6 +86,16 @@ describe("custom decorators", function() {
             return validator.validate(model).then(errors => {
                 errors.length.should.be.equal(1);
                 errors[0].constraints.should.be.eql({ isLongerThan: "firstName must be longer then lastName. Given value: Li" });
+            });
+        });
+
+        it("should include context", function() {
+            const model = new MyClass();
+            model.firstName = "Li";
+            model.lastName = "Kim";
+            return validator.validate(model).then(errors => {
+                errors.length.should.be.equal(1);
+                errors[0].contexts.should.be.eql({ isLongerThan: { foo: "bar" } });
             });
         });
         

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1,5 +1,5 @@
 import "es6-shim";
-import {Contains, Matches, MinLength, ValidateNested} from "../../src/decorator/decorators";
+import {Contains, Matches, MinLength, ValidateNested, IsDefined} from "../../src/decorator/decorators";
 import {Validator} from "../../src/validation/Validator";
 import {ValidationError} from "../../src";
 
@@ -592,14 +592,21 @@ describe("validation options", function() {
                     }
                 })
                 someOtherProperty: string;
+
+                @IsDefined({
+                    context: {
+                        foo: "bar"
+                    }
+                })
+                requiredProperty: string;
             }
 
             const model = new MyClass();
-            // model.someProperty = "hell no world";
             return validator.validate(model).then(errors => {
-                errors.length.should.be.equal(2);
+                errors.length.should.be.equal(3);
                 errors[0].contexts["contains"].should.be.eql({ hi: "there" });
                 errors[1].contexts["contains"].should.be.eql({ bye: "now" });
+                errors[2].contexts["isDefined"].should.be.eql({ foo: "bar" });
             });
         });
 


### PR DESCRIPTION
This PR is a copy of #296 with merge conflicts resolved, fully updated for the latest version of class-validator.

#### UPDATE:
Turns out this code failed in case of asynchronous validator, so I added a new test case and a quick fix.