### PR TITLE
feat: allow custom validators to be conditional #326

### DIFF
--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -161,7 +161,10 @@ export class ValidationExecutor {
         const validationError = this.generateValidationError(object, value, propertyName);
         validationErrors.push(validationError);
 
-        const canValidate = this.conditionalValidations(object, value, conditionalValidationMetadatas);
+        const canValidate = this.conditionalValidations(object, value, [
+            ...conditionalValidationMetadatas,
+            ...customValidationMetadatas
+        ]);
         if (!canValidate) {
             return;
         }
@@ -206,7 +209,13 @@ export class ValidationExecutor {
                                    value: any,
                                    metadatas: ValidationMetadata[]) {
         return metadatas
-            .map(metadata => metadata.constraints[0](object, value))
+            .map(metadata => {
+                if (metadata.constraints && metadata.constraints[0] && metadata.constraints[0] instanceof Function) {
+                    return metadata.constraints[0](object, value);
+                }
+                
+                return true;
+            })
             .reduce((resultA, resultB) => resultA && resultB, true);
     }
 

--- a/test/functional/conditional-validation.spec.ts
+++ b/test/functional/conditional-validation.spec.ts
@@ -1,8 +1,17 @@
 import "es6-shim";
-import {IsNotEmpty, ValidateIf, IsOptional, Equals} from "../../src/decorator/decorators";
-import {Validator} from "../../src/validation/Validator";
-import {ValidatorOptions} from "../../src/validation/ValidatorOptions";
-import {expect, should, use } from "chai";
+import {
+    IsNotEmpty,
+    ValidateIf,
+    IsOptional,
+    Equals
+} from "../../src/decorator/decorators";
+import { Validator } from "../../src/validation/Validator";
+import {
+    ValidationOptions,
+    registerDecorator,
+    ValidationArguments
+} from "../../src";
+import { expect, should, use } from "chai";
 
 import * as chaiAsPromised from "chai-as-promised";
 
@@ -45,7 +54,9 @@ describe("conditional validation", function() {
             errors.length.should.be.equal(1);
             errors[0].target.should.be.equal(model);
             errors[0].property.should.be.equal("title");
-            errors[0].constraints.should.be.eql({ isNotEmpty: "title should not be empty" });
+            errors[0].constraints.should.be.eql({
+                isNotEmpty: "title should not be empty"
+            });
             errors[0].value.should.be.equal("");
         });
     });
@@ -67,7 +78,7 @@ describe("conditional validation", function() {
         });
     });
 
-    it("should validate a property when value is empty", function () {
+    it("should validate a property when value is empty", function() {
         class MyClass {
             @IsOptional()
             @Equals("test")
@@ -79,12 +90,14 @@ describe("conditional validation", function() {
             errors.length.should.be.equal(1);
             errors[0].target.should.be.equal(model);
             errors[0].property.should.be.equal("title");
-            errors[0].constraints.should.be.eql({ equals: "title must be equal to test" });
+            errors[0].constraints.should.be.eql({
+                equals: "title must be equal to test"
+            });
             errors[0].value.should.be.equal("");
         });
     });
 
-    it("should validate a property when value is supplied", function () {
+    it("should validate a property when value is supplied", function() {
         class MyClass {
             @IsOptional()
             @Equals("test")
@@ -96,8 +109,147 @@ describe("conditional validation", function() {
             errors.length.should.be.equal(1);
             errors[0].target.should.be.equal(model);
             errors[0].property.should.be.equal("title");
-            errors[0].constraints.should.be.eql({ equals: "title must be equal to test" });
+            errors[0].constraints.should.be.eql({
+                equals: "title must be equal to test"
+            });
             errors[0].value.should.be.equal("bad_value");
+        });
+    });
+
+    it("should validate a property when no group is supplied - valid", function() {
+        class MyClass {
+            @IsOptional()
+            @Equals(true)
+            flag: boolean = true;
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(0);
+        });
+    });
+
+    it("should validate a property when no group is supplied - optional", function() {
+        class MyClass {
+            @IsOptional()
+            @Equals(true)
+            flag: boolean = undefined;
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(0);
+        });
+    });
+
+    it("should validate a property when no group is supplied - invalid", function() {
+        class MyClass {
+            @IsOptional()
+            @Equals(true)
+            flag: boolean = false;
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(1);
+        });
+    });
+
+    it("should not validate decorators with unspecified groups when a group is specified inside validate()", function() {
+        class MyClass {
+            @IsOptional()
+            @Equals(true)
+            flag: boolean = false;
+        }
+
+        const model = new MyClass();
+        return validator
+            .validate(model, { groups: ["aGroupWhichDoesNotExist"] })
+            .then(errors => {
+                errors.length.should.be.equal(0);
+            });
+    });
+
+    it("should not validate decorators when validation groups are not matching", function() {
+        class MyClass {
+            @IsOptional({ groups: ["group1"] })
+            @Equals(true, { groups: ["group1"] })
+            flag: boolean = false;
+        }
+
+        const model = new MyClass();
+        return validator
+            .validate(model, { groups: ["aGroupWhichDoesNotExist"] })
+            .then(errors => {
+                errors.length.should.be.equal(0);
+            });
+    });
+
+    it("should not validate any decorator if a custom conditional validator is blocking", function() {
+        function IsConditionalNever(validationOptions?: ValidationOptions) {
+            return function(object: Object, propertyName: string) {
+                registerDecorator({
+                    name: "isOptionalCustom",
+                    target: object.constructor,
+                    propertyName: propertyName,
+                    constraints: [
+                        (o: any, value: any) => {
+                            return false;
+                        }
+                    ],
+                    options: validationOptions,
+                    validator: {
+                        validate(value: any, args: ValidationArguments) {
+                            return true;
+                        }
+                    }
+                });
+            };
+        }
+
+        class MyClass {
+            @IsConditionalNever()
+            @Equals(true)
+            flag: boolean = undefined;
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(0);
+        });
+    });
+
+    it("should validate all decorators if a custom conditional validator is blocking", function() {
+        function IsConditionalAlways(validationOptions?: ValidationOptions) {
+            return function(object: Object, propertyName: string) {
+                registerDecorator({
+                    name: "isOptionalCustom",
+                    target: object.constructor,
+                    propertyName: propertyName,
+                    constraints: [
+                        (o: any, value: any) => {
+                            return true;
+                        }
+                    ],
+                    options: validationOptions,
+                    validator: {
+                        validate(value: any, args: ValidationArguments) {
+                            return true;
+                        }
+                    }
+                });
+            };
+        }
+
+        class MyClass {
+            @IsConditionalAlways({ message: "foo" })
+            @Equals(true)
+            flag: boolean = undefined;
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(1);
         });
     });
 });


### PR DESCRIPTION
There are different szenarios where some users want to create custom validators which can handle conditional validation (#326, #196). ValidateIf solves most of the uses cases, but doesn't allow it to react to ValidationOptions.

To allow such a behaviour there might be two approaches:
1. Pass ValidationOptions into ValidationDecoratorOptions.constraints callback.
2. Also do conditional validation for ValidationTypes.CUSTOM_VALIDATION validators.

Would be super nice if somebody can give some feedback.