### PR TITLE
feat: new 'ArrayShouldBeIn' decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "class-validator",
-  "version": "0.10.0-rc.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -331,7 +331,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -343,7 +342,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4977,8 +4975,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -1161,6 +1161,22 @@ export function ArrayContains(values: any[], validationOptions?: ValidationOptio
 }
 
 /**
+ * Checks if array contains all values from the given array of values.
+ */
+export function ArrayShouldBeIn(values: any[], validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.ARRAY_SHOULD_BE_IN,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [values],
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
+/**
  * Checks if array does not contain any of the given values.
  */
 export function ArrayNotContains(values: any[], validationOptions?: ValidationOptions) {

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -89,6 +89,7 @@ export class ValidationTypes {
 
     /* array checkers */
     static ARRAY_CONTAINS = "arrayContains";
+    static ARRAY_SHOULD_BE_IN = "arrayShouldBeIn";
     static ARRAY_NOT_CONTAINS = "arrayNotContains";
     static ARRAY_NOT_EMPTY = "arrayNotEmpty";
     static ARRAY_MIN_SIZE = "arrayMinSize";
@@ -263,6 +264,8 @@ export class ValidationTypes {
             /* array checkers */
             case this.ARRAY_CONTAINS:
                 return eachPrefix + "$property must contain $constraint1 values";
+            case this.ARRAY_SHOULD_BE_IN:
+                return eachPrefix + "$property should be $constraint1 values";
             case this.ARRAY_NOT_CONTAINS:
                 return eachPrefix + "$property should not contain $constraint1 values";
             case this.ARRAY_NOT_EMPTY:

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -173,6 +173,8 @@ export class Validator {
                 return this.contains(value, metadata.constraints[0]);
             case ValidationTypes.NOT_CONTAINS:
                 return this.notContains(value, metadata.constraints[0]);
+            case ValidationTypes.ARRAY_SHOULD_BE_IN:
+                return this.arrayShouldBeIn(value, metadata.constraints[0]);
             case ValidationTypes.IS_ALPHA:
                 return this.isAlpha(value);
             case ValidationTypes.IS_ALPHANUMERIC:
@@ -819,6 +821,17 @@ export class Validator {
             return false;
 
         return !array || values.every(value => array.indexOf(value) === -1);
+    }
+
+    /**
+     * Checks if the array does not contain any other values ​​than the given array.
+     * If null or undefined is given then this function returns false.
+     */
+    arrayShouldBeIn(array: any[], values: any[]) {
+        if (!(array instanceof Array))
+            return false;
+
+        return !array || array.every(value => values.indexOf(value) !== -1);
     }
 
     /**


### PR DESCRIPTION
Hello, sorry for my bad English, I'm French.

I added a validation rule that I found useful.

Principle:
```typescript
import {validate, ArrayShouldBeIn} from "class-validator";

/**
 * all user's roles
 */
export const userRoles: string[] = [
    'SUPERADMIN',
    'ADMIN',
    'MODERATOR',
    'EDITOR',
    'MEMBER',
];

/**
* class User
*/
export class User {
    @ArrayShouldBeIn(userRoles)
    private roles: string[];
};

// validation
const validation = (entity: User) => {
    validate(entity).then(errors => {
        if (errors.length > 0) {
            console.log("validation failed. errors: ", errors);
        } else {
            console.log("validation succeed");
        }
    }
});

let user = new User();

['EDITOR'].forEach(role => user.roles.push(role));
validation(user); // ok

user = new User();

['EDITOR', 'MODERATOR', 'ADMIN'].forEach(role => user.roles.push(role));
validation(user); // ok

user = new User();

['CAR'].forEach(role => user.roles.push(role));
validation(user); // Failed the car value is not in userRoles

```

Thank you !

