### PR TITLE
fix: add locale parameter for isAlpha and isAlphanumeric validators

### DIFF
--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -555,12 +555,13 @@ export function NotContains(seed: string, validationOptions?: ValidationOptions)
 /**
  * Checks if the string contains only letters (a-zA-Z).
  */
-export function IsAlpha(validationOptions?: ValidationOptions) {
+export function IsAlpha(validationOptions?: ValidationOptions, locale: string = "en-US") {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ALPHA,
             target: object.constructor,
             propertyName: propertyName,
+            constraints: [locale], 
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
@@ -570,12 +571,13 @@ export function IsAlpha(validationOptions?: ValidationOptions) {
 /**
  * Checks if the string contains only letters and numbers.
  */
-export function IsAlphanumeric(validationOptions?: ValidationOptions) {
+export function IsAlphanumeric(validationOptions?: ValidationOptions, locale: string = "en-US", ) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ALPHANUMERIC,
             target: object.constructor,
             propertyName: propertyName,
+            constraints: [locale], 
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -555,7 +555,7 @@ export function NotContains(seed: string, validationOptions?: ValidationOptions)
 /**
  * Checks if the string contains only letters (a-zA-Z).
  */
-export function IsAlpha(locale: string = "en-US", validationOptions?: ValidationOptions) {
+export function IsAlpha(locale?: string, validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ALPHA,
@@ -571,7 +571,7 @@ export function IsAlpha(locale: string = "en-US", validationOptions?: Validation
 /**
  * Checks if the string contains only letters and numbers.
  */
-export function IsAlphanumeric(locale: string = "en-US", validationOptions?: ValidationOptions) {
+export function IsAlphanumeric(locale?: string, validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ALPHANUMERIC,

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -504,12 +504,13 @@ export function IsBooleanString(validationOptions?: ValidationOptions) {
 /**
  * Checks if the string is a number.
  */
-export function IsNumberString(validationOptions?: ValidationOptions) {
+export function IsNumberString(validationOptions?: ValidationOptions, NumberOptions?: IsNumberOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_NUMBER_STRING,
             target: object.constructor,
             propertyName: propertyName,
+            constraints: [NumberOptions],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -555,7 +555,7 @@ export function NotContains(seed: string, validationOptions?: ValidationOptions)
 /**
  * Checks if the string contains only letters (a-zA-Z).
  */
-export function IsAlpha(validationOptions?: ValidationOptions, locale: string = "en-US") {
+export function IsAlpha(locale: string = "en-US", validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ALPHA,
@@ -571,7 +571,7 @@ export function IsAlpha(validationOptions?: ValidationOptions, locale: string = 
 /**
  * Checks if the string contains only letters and numbers.
  */
-export function IsAlphanumeric(validationOptions?: ValidationOptions, locale: string = "en-US", ) {
+export function IsAlphanumeric(locale: string = "en-US", validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ALPHANUMERIC,

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -495,7 +495,7 @@ export class Validator {
      * Checks if the string contains only letters (a-zA-Z).
      * If given value is not a string, then it returns false.
      */
-    isAlpha(value: string, locale: ValidatorJS.AlphaLocale = "en-US"): boolean {
+    isAlpha(value: string, locale?: ValidatorJS.AlphaLocale): boolean {
         return typeof value === "string" && this.validatorJs.isAlpha(value, locale);
     }
 
@@ -503,7 +503,7 @@ export class Validator {
      * Checks if the string contains only letters and numbers.
      * If given value is not a string, then it returns false.
      */
-    isAlphanumeric(value: string, locale: ValidatorJS.AlphanumericLocale = "en-US"): boolean {
+    isAlphanumeric(value: string, locale?: ValidatorJS.AlphanumericLocale): boolean {
         return typeof value === "string" && this.validatorJs.isAlphanumeric(value, locale);
     }
 

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -174,9 +174,9 @@ export class Validator {
             case ValidationTypes.NOT_CONTAINS:
                 return this.notContains(value, metadata.constraints[0]);
             case ValidationTypes.IS_ALPHA:
-                return this.isAlpha(value);
+                return this.isAlpha(value, metadata.constraints[0]);
             case ValidationTypes.IS_ALPHANUMERIC:
-                return this.isAlphanumeric(value);
+                return this.isAlphanumeric(value, metadata.constraints[0]);
             case ValidationTypes.IS_DECIMAL:
                 return this.isDecimal(value, metadata.constraints[0]);
             case ValidationTypes.IS_ASCII:
@@ -495,16 +495,16 @@ export class Validator {
      * Checks if the string contains only letters (a-zA-Z).
      * If given value is not a string, then it returns false.
      */
-    isAlpha(value: string): boolean {
-        return typeof value === "string" && this.validatorJs.isAlpha(value);
+    isAlpha(value: string, locale: ValidatorJS.AlphaLocale = "en-US"): boolean {
+        return typeof value === "string" && this.validatorJs.isAlpha(value, locale);
     }
 
     /**
      * Checks if the string contains only letters and numbers.
      * If given value is not a string, then it returns false.
      */
-    isAlphanumeric(value: string): boolean {
-        return typeof value === "string" && this.validatorJs.isAlphanumeric(value);
+    isAlphanumeric(value: string, locale: ValidatorJS.AlphanumericLocale = "en-US"): boolean {
+        return typeof value === "string" && this.validatorJs.isAlphanumeric(value, locale);
     }
 
     /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -1245,7 +1245,7 @@ describe("NotContains", function() {
 
 describe("IsAlpha", function() {
 
-    const constraint = "";
+    const constraint = "en-GB";
     const validValues = ["hellomynameisalex"];
     const invalidValues = [null, undefined, "hello1mynameisalex"];
 
@@ -1263,11 +1263,11 @@ describe("IsAlpha", function() {
     });
 
     it("should not fail if method in validator said that its valid", function() {
-        validValues.forEach(value => validator.isAlpha(value).should.be.true);
+        validValues.forEach(value => validator.isAlpha(value, constraint).should.be.true);
     });
 
     it("should fail if method in validator said that its invalid", function() {
-        invalidValues.forEach(value => validator.isAlpha(value).should.be.false);
+        invalidValues.forEach(value => validator.isAlpha(value, constraint).should.be.false);
     });
 
     it("should return error object with proper data", function(done) {


### PR DESCRIPTION
This commit adds the feature to add locale to both isAlpha and isAlphanumeric with default as en-US