### PR TITLE
Add check for the IsPhoneNumber validator function to match E.164

### DIFF
--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -686,7 +686,7 @@ export class Validator {
     isPhoneNumber(value: string, region: string): boolean {
         try {
             const phoneNum = this.libPhoneNumber.phoneUtil.parseAndKeepRawInput(value, region);
-            return this.libPhoneNumber.phoneUtil.isValidNumber(phoneNum);
+            return /^\+?[\d\s]*(\([\d\s]*[\d][\d\s]*\))?[\d\s]*[\d]$/.test(phoneNum.values_["5"]) && this.libPhoneNumber.phoneUtil.isValidNumber(phoneNum);
         } catch (error) {
             // logging?
             return false;

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -2944,7 +2944,7 @@ describe("isPhoneNumber", function() {
             "+41 (0)311111111", "+41 (0)31 633 60 01", "+41 (0)79 4 666 666", "+41 (0)75 416 20 30",
             "+49 9072 1111"
         ];
-        const invalidValues = [undefined, null, "asdf", "1"];
+        const invalidValues = [undefined, null, "asdf", "1", "+41 9072 2222+-=-=", "+49 (9072 1111", "+41 ( )9073 4161"];
 
         class MyClass {
             @IsPhoneNumber("CH")


### PR DESCRIPTION
I found the problem with validating phone numbers. (issue #417 )

This issue occurs due to the peculiarity of the validation of the phone number in `google-libphonenumber`. The `parseAndKeepRawInput` method ignores the contents of the line after the phone number. At the same time, the `isValidNumber` method - checks the already processed string and not the one that was originally (`raw_input`).
In this solution, a regular expression was added to check for matching with the `E.164` standard.