### PR TITLE
feat: support ES6 Map and Set for regular validators with each option

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,13 @@
 export function isPromise<T = any>(p: any): p is Promise<T> {
     return p !== null && typeof p === "object" && typeof p.then === "function";
 }
+
+/**
+ * Convert Map, Set to Array
+ */
+export function convertToArray<T>(val: Array<T> | Set<T> | Map<any, T>): Array<T> {
+    if (val instanceof Map) {
+        return Array.from(val.values());
+    }
+    return Array.isArray(val) ? val : Array.from(val);
+}

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -8,7 +8,7 @@ import {ValidationTypes} from "./ValidationTypes";
 import {ConstraintMetadata} from "../metadata/ConstraintMetadata";
 import {ValidationArguments} from "./ValidationArguments";
 import {ValidationUtils} from "./ValidationUtils";
-import {isPromise} from "../utils";
+import {isPromise, convertToArray} from "../utils";
 
 /**
  * Executes validation over given object.
@@ -225,8 +225,9 @@ export class ValidationExecutor {
         return metadatas
             .filter(metadata => {
                 if (metadata.each) {
-                    if (value instanceof Array) {
-                        return !value.every((subValue: any) => this.validator.validateValueByMetadata(subValue, metadata));
+                    if (value instanceof Array || value instanceof Set || value instanceof Map) {
+                        const arrayValue = convertToArray(value);
+                        return !arrayValue.every((subValue: any) => this.validator.validateValueByMetadata(subValue, metadata));
                     }
 
                 } else {
@@ -259,7 +260,7 @@ export class ValidationExecutor {
                         constraints: metadata.constraints
                     };
 
-                    if (!metadata.each || !(value instanceof Array)) {
+                    if (!metadata.each || !(value instanceof Array || value instanceof Set || value instanceof Map)) {
                         const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments);
                         if (isPromise(validatedValue)) {
                             const promise = validatedValue.then(isValid => {
@@ -279,8 +280,10 @@ export class ValidationExecutor {
                         return;
                     }
 
+                    // convert set and map into array
+                    const arrayValue = convertToArray(value);
                     // Validation needs to be applied to each array item
-                    const validatedSubValues = value.map((subValue: any) => customConstraintMetadata.instance.validate(subValue, validationArguments));
+                    const validatedSubValues = arrayValue.map((subValue: any) => customConstraintMetadata.instance.validate(subValue, validationArguments));
                     const validationIsAsync = validatedSubValues
                         .some((validatedSubValue: boolean | Promise<boolean>) => isPromise(validatedSubValue));
 
@@ -338,28 +341,11 @@ export class ValidationExecutor {
 
             const targetSchema = typeof metadata.target === "string" ? metadata.target as string : undefined;
 
-            if (value instanceof Array) {
-                value.forEach((subValue: any, index: number) => {
+            if (value instanceof Array || value instanceof Set || value instanceof Map) {
+                // Treats Set as an array - as index of Set value is value itself and it is common case to have Object as value
+                const arrayLikeValue = value instanceof Set ? Array.from(value) : value;
+                arrayLikeValue.forEach((subValue: any, index: any) => {
                     const validationError = this.generateValidationError(value, subValue, index.toString());
-                    errors.push(validationError);
-
-                    this.execute(subValue, targetSchema, validationError.children);
-                });
-
-            } else if (value instanceof Set) {
-                let index = 0;
-                value.forEach((subValue: any) => {
-                    const validationError = this.generateValidationError(value, subValue, index.toString());
-                    errors.push(validationError);
-
-                    this.execute(subValue, targetSchema, validationError.children);
-
-                    ++index;
-                });
-
-            } else if (value instanceof Map) {
-                value.forEach((subValue: any, key: any) => {
-                    const validationError = this.generateValidationError(value, subValue, key.toString());
                     errors.push(validationError);
 
                     this.execute(subValue, targetSchema, validationError.children);

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -144,127 +144,384 @@ describe("validation options", function() {
 
     describe("each", function() {
 
-        it("should apply validation to each item in the array", function() {
-            class MyClass {
-                @Contains("hello", {
-                    each: true
-                })
-                someProperty: string[];
-            }
+        describe("Array", function() {
 
-            const model = new MyClass();
-            model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
-            return validator.validate(model).then(errors => {
-                errors.length.should.be.equal(1);
-                errors[0].constraints.should.be.eql({ contains: "each value in someProperty must contain a hello string" });
-                errors[0].value.should.be.equal(model.someProperty);
-                errors[0].target.should.be.equal(model);
-                errors[0].property.should.be.equal("someProperty");
+            it("should apply validation to each item in the array", function() {
+                class MyClass {
+                    @Contains("hello", {
+                        each: true
+                    })
+                    someProperty: string[];
+                }
+
+                const model = new MyClass();
+                model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ contains: "each value in someProperty must contain a hello string" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class to array items (but not array itself)", function() {
+                @ValidatorConstraint({ name: "customIsNotArrayConstraint", async: false })
+                class CustomIsNotArrayConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        return !(value instanceof Array);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomIsNotArrayConstraint, {
+                        each: true
+                    })
+                    someArrayOfNonArrayItems: string[];
+                }
+
+                const model = new MyClass();
+                model.someArrayOfNonArrayItems = ["not array", "also not array", "not array at all"];
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(0);
+                });
+            });
+
+            it("should apply validation via custom constraint class with synchronous logic to each item in the array", function() {
+                @ValidatorConstraint({ name: "customContainsHelloConstraint", async: false })
+                class CustomContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        return !(value instanceof Array) && String(value).includes("hello");
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: string[];
+                }
+
+                const model = new MyClass();
+                model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class with async logic to each item in the array", function() {
+                @ValidatorConstraint({ name: "customAsyncContainsHelloConstraint", async: true })
+                class CustomAsyncContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        const isValid = !(value instanceof Array) && String(value).includes("hello");
+
+                        return Promise.resolve(isValid);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomAsyncContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: string[];
+                }
+
+                const model = new MyClass();
+                model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customAsyncContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class with mixed (synchronous + async) logic to each item in the array", function() {
+                @ValidatorConstraint({ name: "customMixedContainsHelloConstraint", async: true })
+                class CustomMixedContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        const isValid = !(value instanceof Array) && String(value).includes("hello");
+
+                        return isValid ? isValid : Promise.resolve(isValid);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomMixedContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: string[];
+                }
+
+                const model = new MyClass();
+                model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customMixedContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
             });
         });
 
-        it("should apply validation via custom constraint class to array items (but not array itself)", function() {
-            @ValidatorConstraint({ name: "customIsNotArrayConstraint", async: false })
-            class CustomIsNotArrayConstraint implements ValidatorConstraintInterface {
-                validate(value: any) {
-                    return !(value instanceof Array);
+        describe("Set", function() {
+
+            it("should apply validation to each item in the Set", function() {
+                class MyClass {
+                    @Contains("hello", {
+                        each: true
+                    })
+                    someProperty: Set<string>;
                 }
-            }
 
-            class MyClass {
-                @Validate(CustomIsNotArrayConstraint, {
-                    each: true
-                })
-                someArrayOfNonArrayItems: string[];
-            }
-
-            const model = new MyClass();
-            model.someArrayOfNonArrayItems = ["not array", "also not array", "not array at all"];
-            return validator.validate(model).then(errors => {
-                errors.length.should.be.equal(0);
+                const model = new MyClass();
+                model.someProperty = new Set<string>(["hell no world", "hello", "helo world", "hello world", "hello dear friend"]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ contains: "each value in someProperty must contain a hello string" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
             });
+
+            it("should apply validation via custom constraint class to Set items (but not Set itself)", function() {
+                @ValidatorConstraint({ name: "customIsNotSetConstraint", async: false })
+                class CustomIsNotSetConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        return !(value instanceof Set);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomIsNotSetConstraint, {
+                        each: true
+                    })
+                    someSetOfNonSetItems: Set<string>;
+                }
+
+                const model = new MyClass();
+                model.someSetOfNonSetItems = new Set<string>(["not array", "also not array", "not array at all"]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(0);
+                });
+            });
+
+            it("should apply validation via custom constraint class with synchronous logic to each item in the Set", function() {
+                @ValidatorConstraint({ name: "customContainsHelloConstraint", async: false })
+                class CustomContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        return !(value instanceof Set) && String(value).includes("hello");
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: Set<string>;
+                }
+
+                const model = new MyClass();
+                model.someProperty = new Set<string>(["hell no world", "hello", "helo world", "hello world", "hello dear friend"]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class with async logic to each item in the Set", function() {
+                @ValidatorConstraint({ name: "customAsyncContainsHelloConstraint", async: true })
+                class CustomAsyncContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        const isValid = !(value instanceof Set) && String(value).includes("hello");
+
+                        return Promise.resolve(isValid);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomAsyncContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: Set<string>;
+                }
+
+                const model = new MyClass();
+                model.someProperty = new Set<string>(["hell no world", "hello", "helo world", "hello world", "hello dear friend"]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customAsyncContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class with mixed (synchronous + async) logic to each item in the Set", function() {
+                @ValidatorConstraint({ name: "customMixedContainsHelloConstraint", async: true })
+                class CustomMixedContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        const isValid = !(value instanceof Set) && String(value).includes("hello");
+
+                        return isValid ? isValid : Promise.resolve(isValid);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomMixedContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: Set<string>;
+                }
+
+                const model = new MyClass();
+                model.someProperty = new Set<string>(["hell no world", "hello", "helo world", "hello world", "hello dear friend"]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customMixedContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
         });
 
-        it("should apply validation via custom constraint class with synchronous logic to each item in the array", function() {
-            @ValidatorConstraint({ name: "customContainsHelloConstraint", async: false })
-            class CustomContainsHelloConstraint implements ValidatorConstraintInterface {
-                validate(value: any) {
-                    return !(value instanceof Array) && String(value).includes("hello");
+        describe("Map", function() {
+
+            it("should apply validation to each item in the Map", function() {
+                class MyClass {
+                    @Contains("hello", {
+                        each: true
+                    })
+                    someProperty: Map<string, string>;
                 }
-            }
 
-            class MyClass {
-                @Validate(CustomContainsHelloConstraint, {
-                    each: true
-                })
-                someProperty: string[];
-            }
-
-            const model = new MyClass();
-            model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
-            return validator.validate(model).then(errors => {
-                errors.length.should.be.equal(1);
-                errors[0].constraints.should.be.eql({ customContainsHelloConstraint: "" });
-                errors[0].value.should.be.equal(model.someProperty);
-                errors[0].target.should.be.equal(model);
-                errors[0].property.should.be.equal("someProperty");
+                const model = new MyClass();
+                model.someProperty = new Map<string, string>([["key1", "hell no world"], ["key2", "hello"], ["key3", "helo world"], ["key4", "hello world"], ["key5", "hello dear friend"]]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ contains: "each value in someProperty must contain a hello string" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
             });
-        });
 
-        it("should apply validation via custom constraint class with async logic to each item in the array", function() {
-            @ValidatorConstraint({ name: "customAsyncContainsHelloConstraint", async: true })
-            class CustomAsyncContainsHelloConstraint implements ValidatorConstraintInterface {
-                validate(value: any) {
-                    const isValid = !(value instanceof Array) && String(value).includes("hello");
-
-                    return Promise.resolve(isValid);
+            it("should apply validation via custom constraint class to Map items (but not Map itself)", function() {
+                @ValidatorConstraint({ name: "customIsNotMapConstraint", async: false })
+                class CustomIsNotMapConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        return !(value instanceof Map);
+                    }
                 }
-            }
 
-            class MyClass {
-                @Validate(CustomAsyncContainsHelloConstraint, {
-                    each: true
-                })
-                someProperty: string[];
-            }
-
-            const model = new MyClass();
-            model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
-            return validator.validate(model).then(errors => {
-                errors.length.should.be.equal(1);
-                errors[0].constraints.should.be.eql({ customAsyncContainsHelloConstraint: "" });
-                errors[0].value.should.be.equal(model.someProperty);
-                errors[0].target.should.be.equal(model);
-                errors[0].property.should.be.equal("someProperty");
-            });
-        });
-
-        it("should apply validation via custom constraint class with mixed (synchronous + async) logic to each item in the array", function() {
-            @ValidatorConstraint({ name: "customMixedContainsHelloConstraint", async: true })
-            class CustomMixedContainsHelloConstraint implements ValidatorConstraintInterface {
-                validate(value: any) {
-                    const isValid = !(value instanceof Array) && String(value).includes("hello");
-
-                    return isValid ? isValid : Promise.resolve(isValid);
+                class MyClass {
+                    @Validate(CustomIsNotMapConstraint, {
+                        each: true
+                    })
+                    someArrayOfNonArrayItems: Map<string, string>;
                 }
-            }
 
-            class MyClass {
-                @Validate(CustomMixedContainsHelloConstraint, {
-                    each: true
-                })
-                someProperty: string[];
-            }
-
-            const model = new MyClass();
-            model.someProperty = ["hell no world", "hello", "helo world", "hello world", "hello dear friend"];
-            return validator.validate(model).then(errors => {
-                errors.length.should.be.equal(1);
-                errors[0].constraints.should.be.eql({ customMixedContainsHelloConstraint: "" });
-                errors[0].value.should.be.equal(model.someProperty);
-                errors[0].target.should.be.equal(model);
-                errors[0].property.should.be.equal("someProperty");
+                const model = new MyClass();
+                model.someArrayOfNonArrayItems = new Map<string, string>([["key1", "not array"], ["key2", "also not array"], ["key3", "not array at all"]]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(0);
+                });
             });
+
+            it("should apply validation via custom constraint class with synchronous logic to each item in the Map", function() {
+                @ValidatorConstraint({ name: "customContainsHelloConstraint", async: false })
+                class CustomContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        return !(value instanceof Map) && String(value).includes("hello");
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: Map<string, string>;
+                }
+
+                const model = new MyClass();
+                model.someProperty = new Map<string, string>([["key1", "hell no world"], ["key2", "hello"], ["key3", "helo world"], ["key4", "hello world"], ["key5", "hello dear friend"]]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class with async logic to each item in the Map", function() {
+                @ValidatorConstraint({ name: "customAsyncContainsHelloConstraint", async: true })
+                class CustomAsyncContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        const isValid = !(value instanceof Map) && String(value).includes("hello");
+
+                        return Promise.resolve(isValid);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomAsyncContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: Map<string, string>;
+                }
+
+                const model = new MyClass();
+                model.someProperty = new Map<string, string>([["key1", "hell no world"], ["key2", "hello"], ["key3", "helo world"], ["key4", "hello world"], ["key5", "hello dear friend"]]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customAsyncContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
+            it("should apply validation via custom constraint class with mixed (synchronous + async) logic to each item in the Map", function() {
+                @ValidatorConstraint({ name: "customMixedContainsHelloConstraint", async: true })
+                class CustomMixedContainsHelloConstraint implements ValidatorConstraintInterface {
+                    validate(value: any) {
+                        const isValid = !(value instanceof Map) && String(value).includes("hello");
+
+                        return isValid ? isValid : Promise.resolve(isValid);
+                    }
+                }
+
+                class MyClass {
+                    @Validate(CustomMixedContainsHelloConstraint, {
+                        each: true
+                    })
+                    someProperty: Map<string, string>;
+                }
+
+                const model = new MyClass();
+                model.someProperty = new Map<string, string>([["key1", "hell no world"], ["key2", "hello"], ["key3", "helo world"], ["key4", "hello world"], ["key5", "hello dear friend"]]);
+                return validator.validate(model).then(errors => {
+                    errors.length.should.be.equal(1);
+                    errors[0].constraints.should.be.eql({ customMixedContainsHelloConstraint: "" });
+                    errors[0].value.should.be.equal(model.someProperty);
+                    errors[0].target.should.be.equal(model);
+                    errors[0].property.should.be.equal("someProperty");
+                });
+            });
+
         });
 
     });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,0 +1,64 @@
+import "es6-shim";
+
+import { should, use } from "chai";
+
+import * as chaiAsPromised from "chai-as-promised";
+import { convertToArray } from "../src/utils";
+
+should();
+use(chaiAsPromised);
+
+// -------------------------------------------------------------------------
+// Setup
+// -------------------------------------------------------------------------
+
+
+// -------------------------------------------------------------------------
+// Specifications: utils unit tests
+// -------------------------------------------------------------------------
+
+describe("utils", function () {
+
+    describe("convertToArray", function () {
+
+        it("convert Set into array", function () {
+
+            const setExample = new Set<string>();
+            setExample.add("hello");
+            setExample.add("world");
+
+            const newArr = convertToArray(setExample);
+            newArr.should.be.instanceOf(Array);
+            newArr.length.should.be.equal(2);
+            newArr.should.contains("hello");
+            newArr.should.contains("world");
+        });
+
+
+        it("convert Map into array of values", function () {
+
+            const map = new Map<string, string>();
+            map.set("key1", "hello");
+            map.set("key2", "world");
+
+            const newArr = convertToArray(map);
+            newArr.should.be.instanceOf(Array);
+            newArr.length.should.be.equal(2);
+            newArr.should.contains("hello");
+            newArr.should.contains("world");
+        });
+
+        it("should return array untouched", function () {
+
+            const arr = ["hello", "world"];
+
+            const newArr = convertToArray(arr);
+            arr.should.be.instanceOf(Array);
+            arr.length.should.be.equal(2);
+            arr.should.contains("hello");
+            arr.should.contains("world");
+        });
+
+    });
+
+});


### PR DESCRIPTION
Looks like we do not support `each` option for Map and Set (https://github.com/typestack/class-validator/issues/428)

This PR add support Map/Set for regular validators and custom validators `@Validate`.

Also small unit tests added.

Close https://github.com/typestack/class-validator/issues/428