### PR TITLE
fix: Make IsMobilePhone supports both string and array locale

### DIFF
--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -607,7 +607,7 @@ export function IsAlpha(locale?: string, validationOptions?: ValidationOptions) 
             type: ValidationTypes.IS_ALPHA,
             target: object.constructor,
             propertyName: propertyName,
-            constraints: [locale], 
+            constraints: [locale],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
@@ -623,7 +623,7 @@ export function IsAlphanumeric(locale?: string, validationOptions?: ValidationOp
             type: ValidationTypes.IS_ALPHANUMERIC,
             target: object.constructor,
             propertyName: propertyName,
-            constraints: [locale], 
+            constraints: [locale],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
@@ -969,7 +969,7 @@ export function IsLowercase(validationOptions?: ValidationOptions) {
 }
 
 /**
- * Checks if the string is a mobile phone number (locale is one of ['zh-CN', 'zh-TW', 'en-ZA', 'en-AU', 'en-HK',
+ * Checks if the string is a mobile phone number (locale is one of ['zh-CN', 'zh-HK', 'zh-TW', 'en-ZA', 'en-AU',
  * 'pt-PT', 'fr-FR', 'el-GR', 'en-GB', 'en-US', 'en-ZM', 'ru-RU', 'nb-NO', 'nn-NO', 'vi-VN', 'en-NZ']).
  */
 export function IsMobilePhone(locale: string, validationOptions?: ValidationOptions) {

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -972,7 +972,7 @@ export function IsLowercase(validationOptions?: ValidationOptions) {
  * Checks if the string is a mobile phone number (locale is one of ['zh-CN', 'zh-HK', 'zh-TW', 'en-ZA', 'en-AU',
  * 'pt-PT', 'fr-FR', 'el-GR', 'en-GB', 'en-US', 'en-ZM', 'ru-RU', 'nb-NO', 'nn-NO', 'vi-VN', 'en-NZ']).
  */
-export function IsMobilePhone(locale: string, validationOptions?: ValidationOptions) {
+export function IsMobilePhone(locale: string | Array<string>, validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_MOBILE_PHONE,

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -729,7 +729,7 @@ export class Validator {
     }
 
     /**
-     * Checks if the string is a mobile phone number (locale is one of ['zh-CN', 'zh-TW', 'en-ZA', 'en-AU', 'en-HK',
+     * Checks if the string is a mobile phone number (locale is one of ['zh-CN', 'zh-HK', 'zh-TW', 'en-ZA', 'en-AU',
      * 'pt-PT', 'fr-FR', 'el-GR', 'en-GB', 'en-US', 'en-ZM', 'ru-RU', 'nb-NO', 'nn-NO', 'vi-VN', 'en-NZ']).
      * If given value is not a string, then it returns false.
      */

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -733,7 +733,7 @@ export class Validator {
      * 'pt-PT', 'fr-FR', 'el-GR', 'en-GB', 'en-US', 'en-ZM', 'ru-RU', 'nb-NO', 'nn-NO', 'vi-VN', 'en-NZ']).
      * If given value is not a string, then it returns false.
      */
-    isMobilePhone(value: unknown, locale: ValidatorJS.MobilePhoneLocale): boolean {
+    isMobilePhone(value: unknown, locale: ValidatorJS.MobilePhoneLocale | ValidatorJS.MobilePhoneLocale[]): boolean {
         return typeof value === "string" && this.validatorJs.isMobilePhone(value, locale);
     }
 

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -73,6 +73,7 @@ import {
     IsPhoneNumber,
     IsISO31661Alpha2,
     IsISO31661Alpha3,
+    IsMobilePhone,
 } from "../../src/decorator/decorators";
 import {Validator} from "../../src/validation/Validator";
 import {ValidatorOptions} from "../../src/validation/ValidatorOptions";
@@ -467,7 +468,7 @@ describe("IsLatLong", function () {
 
     it("should fail if validator.validate said that its invalid", function (done) {
         checkInvalidValues(new MyClass(), invalidValues, done);
-    }); 
+    });
 
 });
 describe("IsLatitude", function () {
@@ -3068,6 +3069,51 @@ describe("IsMilitaryTime", function() {
         const invalidValues = [undefined, null, "23:00 and invalid counterpart"];
         checkInvalidValues(new MyClass(), invalidValues, done);
     });
+
+});
+
+describe("isMobilePhone", function () {
+    describe("with string", function () {
+        const validValue = ["+8613037427767", "18996565961"];
+        const invalidValue = ["1303742776", "39167211"];
+
+        class MyClass {
+            @IsMobilePhone("zh-CN")
+            someProperty: string;
+        }
+
+        it("should not fail if validator.validate said that its valid", function (done) {
+            checkValidValues(new MyClass(), validValue, done);
+        });
+
+        it("should fail if validator.validate said that its invalid", function (done) {
+            checkInvalidValues(new MyClass(), invalidValue, done);
+        });
+    });
+
+    describe("with array", function () {
+        const validValue = [
+            "+8613037427767", "18996565961",
+            "91054832", "85292449908"
+        ];
+        const invalidValue = [
+            "1303742776", "39167211", "852924499"
+        ];
+
+        class MyClass {
+            @IsMobilePhone(["zh-CN", "zh-HK"])
+            someProperty: string;
+        }
+
+        it("should not fail if validator.validate said that its valid", function (done) {
+            checkValidValues(new MyClass(), validValue, done);
+        });
+
+        it("should fail if validator.validate said that its invalid", function (done) {
+            checkInvalidValues(new MyClass(), invalidValue, done);
+        });
+    });
+
 
 });
 


### PR DESCRIPTION
fix: Modify 'en-HK' to 'zh-HK'
feat: IsMobilePhone supports both string and array locale

close issues #440 