### PR TITLE
feat: add options for isISO8601 validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ validator.isIP(str, version); // Checks if the string is an IP (version 4 or 6).
 validator.isPort(str); // Check if the string is a valid port number.
 validator.isISBN(str, version); // Checks if the string is an ISBN (version 10 or 13).
 validator.isISIN(str); // Checks if the string is an ISIN (stock/security identifier).
-validator.isISO8601(strict, str); // Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
+validator.isISO8601(str, options); // Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
 validator.isJSON(str); // Checks if the string is valid JSON (note: uses JSON.parse).
 validator.isJWT(str) // Checks if the string is valid JWT.
 validator.isObject(object); // Checks if the object is valid Object (null, functions, arrays will return false)
@@ -927,12 +927,12 @@ validator.isInstance(value, target); // Checks value is an instance of the targe
 | `@IsVariableWidth()`                            | Checks if the string contains a mixture of full and half-width chars.                                                            |
 | `@IsHexColor()`                                 | Checks if the string is a hexadecimal color.                                                                                     |
 | `@IsHexadecimal()`                              | Checks if the string is a hexadecimal number.                                                                                    |
-| `@IsMACAddress()`                              | Checks if the string is a MAC Address.                                                                                            |
+| `@IsMACAddress()`                               | Checks if the string is a MAC Address.                                                                                            |
 | `@IsIP(version?: "4"\|"6")`                     | Checks if the string is an IP (version 4 or 6).                                                                                  |
 | `@IsPort()`                                     | Check if the string is a valid port number.                                                                                      |
 | `@IsISBN(version?: "10"\|"13")`                 | Checks if the string is an ISBN (version 10 or 13).                                                                              |
 | `@IsISIN()`                                     | Checks if the string is an ISIN (stock/security identifier).                                                                     |
-| `@IsISO8601(strict?: boolean)`                  | Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.                                                                               |
+| `@IsISO8601(options?: IsISO8601Options)`        | Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.                                                                               |
 | `@IsJSON()`                                     | Checks if the string is valid JSON.                                                                                              |
 | `@IsJWT()`                                      | Checks if the string is valid JWT.                                                                                                |
 | `@IsObject()`                                   | Checks if the object is valid Object (null, functions, arrays will return false).                                                                                              |

--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ validator.isHexadecimal(str); // Checks if the string is a hexadecimal number.
 validator.isIP(str, version); // Checks if the string is an IP (version 4 or 6).
 validator.isISBN(str, version); // Checks if the string is an ISBN (version 10 or 13).
 validator.isISIN(str); // Checks if the string is an ISIN (stock/security identifier).
-validator.isISO8601(str); // Checks if the string is a valid ISO 8601 date.
+validator.isISO8601(strict, str); // Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
 validator.isJSON(str); // Checks if the string is valid JSON (note: uses JSON.parse).
 validator.isLowercase(str); // Checks if the string is lowercase.
 validator.isMobilePhone(str, locale); // Checks if the string is a mobile phone number.
@@ -920,7 +920,7 @@ validator.isInstance(value, target); // Checks value is an instance of the targe
 | `@IsIP(version?: "4"\|"6")`                     | Checks if the string is an IP (version 4 or 6).                                                                                  |
 | `@IsISBN(version?: "10"\|"13")`                 | Checks if the string is an ISBN (version 10 or 13).                                                                              |
 | `@IsISIN()`                                     | Checks if the string is an ISIN (stock/security identifier).                                                                     |
-| `@IsISO8601()`                                  | Checks if the string is a valid ISO 8601 date.                                                                                   |
+| `@IsISO8601(strict?: boolean)`                  | Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.                                                                               |
 | `@IsJSON()`                                     | Checks if the string is valid JSON.                                                                                              |
 | `@IsLowercase()`                                | Checks if the string is lowercase.                                                                                               |
 | `@IsMobilePhone(locale: string)`                | Checks if the string is a mobile phone number.                                                                                    |

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -846,14 +846,15 @@ export function IsISIN(validationOptions?: ValidationOptions) {
 }
 
 /**
- * Checks if the string is a valid ISO 8601 date.
+ * Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
  */
-export function IsISO8601(validationOptions?: ValidationOptions) {
+export function IsISO8601(strict?: boolean, validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ISO8601,
             target: object.constructor,
             propertyName: propertyName,
+            constraints: [strict],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -607,7 +607,7 @@ export function IsAlpha(locale?: string, validationOptions?: ValidationOptions) 
             type: ValidationTypes.IS_ALPHA,
             target: object.constructor,
             propertyName: propertyName,
-            constraints: [locale], 
+            constraints: [locale],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
@@ -623,7 +623,7 @@ export function IsAlphanumeric(locale?: string, validationOptions?: ValidationOp
             type: ValidationTypes.IS_ALPHANUMERIC,
             target: object.constructor,
             propertyName: propertyName,
-            constraints: [locale], 
+            constraints: [locale],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
@@ -910,13 +910,13 @@ export function IsISIN(validationOptions?: ValidationOptions) {
 /**
  * Checks if the string is a valid ISO 8601 date. Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
  */
-export function IsISO8601(strict?: boolean, validationOptions?: ValidationOptions) {
+export function IsISO8601(options?: ValidatorJS.IsISO8601Options, validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.IS_ISO8601,
             target: object.constructor,
             propertyName: propertyName,
-            constraints: [strict],
+            constraints: [options],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -719,8 +719,8 @@ export class Validator {
      * If given value is not a string, then it returns false.
      * Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
      */
-    isISO8601(value: unknown, strict?: boolean): boolean {
-        return typeof value === "string" && this.validatorJs.isISO8601(value, {strict});
+    isISO8601(value: unknown, options?: ValidatorJS.IsISO8601Options): boolean {
+        return typeof value === "string" && this.validatorJs.isISO8601(value, options);
     }
 
     /**

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -274,7 +274,7 @@ export class Validator {
                 return this.isHash(value, metadata.constraints[0]);
             case ValidationTypes.IS_ISSN:
                 return this.isISSN(value, metadata.constraints[0]);
-                
+
             /* array checkers */
             case ValidationTypes.ARRAY_CONTAINS:
                 return this.arrayContains(value, metadata.constraints[0]);
@@ -444,7 +444,7 @@ export class Validator {
                 return false;
             }
         }
-        
+
         return Number.isFinite(value);
     }
 
@@ -701,7 +701,6 @@ export class Validator {
     /**
      * Checks if the string is an ISBN (version 10 or 13).
      * If given value is not a string, then it returns false.
-     * Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
      */
     isISBN(value: unknown, version?: number): boolean {
         return typeof value === "string" && this.validatorJs.isISBN(value, version);

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -212,7 +212,7 @@ export class Validator {
             case ValidationTypes.IS_ISIN:
                 return this.isISIN(value);
             case ValidationTypes.IS_ISO8601:
-                return this.isISO8601(value);
+                return this.isISO8601(value, metadata.constraints[0]);
             case ValidationTypes.IS_JSON:
                 return this.isJSON(value);
             case ValidationTypes.IS_LOWERCASE:
@@ -630,6 +630,7 @@ export class Validator {
     /**
      * Checks if the string is an ISBN (version 10 or 13).
      * If given value is not a string, then it returns false.
+     * Use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.
      */
     isISBN(value: string, version?: number): boolean {
         return typeof value === "string" && this.validatorJs.isISBN(value, version);
@@ -647,8 +648,8 @@ export class Validator {
      * Checks if the string is a valid ISO 8601 date.
      * If given value is not a string, then it returns false.
      */
-    isISO8601(value: string): boolean {
-        return typeof value === "string" && this.validatorJs.isISO8601(value);
+    isISO8601(value: string, strict?: boolean): boolean {
+        return typeof value === "string" && this.validatorJs.isISO8601(value, {strict});
     }
 
     /**


### PR DESCRIPTION
This PR is a reference to #412 . Now we can use the option strict = true for additional checks for a valid date, e.g. invalidates dates like 2019-02-29.