### PR TITLE
fix: optional `constraints` property in ValidationError

### DIFF
--- a/src/validation/ValidationError.ts
+++ b/src/validation/ValidationError.ts
@@ -25,7 +25,7 @@ export class ValidationError {
     /**
      * Constraints that failed validation with error messages.
      */
-    constraints: {
+    constraints?: {
         [type: string]: string
     };
 


### PR DESCRIPTION
## Motivation

I had this log method when an error was appearing : 

```ts
function logErrors(fieldErrors: { requestField: string; error: ValidationError }[]): void {
    console.log(fieldErrors);
    const errorMessages = fieldErrors
        .map(({ requestField, error }) => `- ${requestField}: ${Object.values(error.constraints)}`)
        .join('\n\t');
    logger.error(new Error(`Bad request.\n\t${errorMessages}`));
}
``` 

This triggered a runtime error when error.constraints was undefined. This is the kind of error that could be avoided by Typescript check if the field was optional in ts declaration

## Error reproduction

ValidationError.constraint can be undefined if there is only a nested validation error

## Others tracks of resolution

Maybe instead of changing the declaration, it's better to make sure the field is never undefined. We can discuss about this and I will modify the PR