### PR TITLE
StringEnum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,8 @@ validator.isInstance(value, target); // Checks value is an instance of the targe
 | `@IsNumber(options: IsNumberOptions)`           | Checks if the value is a number.                                                                                                 |
 | `@IsInt()`                                      | Checks if the value is an integer number.                                                                                        |
 | `@IsArray()`                                    | Checks if the value is an array                                                                                                  |
-| `@IsEnum(entity: object)`                         | Checks if the value is an valid enum                                                                                           |
+| `@IsEnum(entity: object)`                        | Checks if the value is a valid enum                                                                                             |
+| `@IsStringEnum(entity: object)`                  | Checks if the value is a valid enum and a string                                                                                |
 | **Number validation decorators**                                                                                                                                                   |
 | `@IsDivisibleBy(num: number)`                   | Checks if the value is a number that's divisible by another.                                                                     |
 | `@IsPositive()`                                 | Checks if the value is a positive number.                                                                                        |

--- a/sample/sample1-simple-validation/Post.ts
+++ b/sample/sample1-simple-validation/Post.ts
@@ -1,4 +1,4 @@
-import {Contains, IsInt, MinLength, MaxLength, IsEmail, IsFQDN, IsDate, ArrayNotEmpty, ArrayMinSize, ArrayMaxSize, IsEnum} from "../../src/decorator/decorators";
+import {Contains, IsInt, MinLength, MaxLength, IsEmail, IsFQDN, IsDate, ArrayNotEmpty, ArrayMinSize, ArrayMaxSize, IsStringEnum} from "../../src/decorator/decorators";
 
 export enum PostType {
     Public,
@@ -33,6 +33,6 @@ export class Post {
     @MaxLength(50, { each: true, message: "Tag is too long. Maximal length is $value characters" })
     tags: string[];
 
-    @IsEnum(PostType)
+    @IsStringEnum(PostType)
     type: PostType;
 }

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -6,6 +6,7 @@ import {ValidationMetadataArgs} from "../metadata/ValidationMetadataArgs";
 import {ConstraintMetadata} from "../metadata/ConstraintMetadata";
 import {getFromContainer} from "../container";
 import {MetadataStorage} from "../metadata/MetadataStorage";
+import { getEnumStringValues } from "../utils";
 
 // -------------------------------------------------------------------------
 // System
@@ -403,6 +404,22 @@ export function IsEnum(entity: Object, validationOptions?: ValidationOptions) {
             target: object.constructor,
             propertyName: propertyName,
             constraints: [entity],
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
+/**
+ * Checks if a value is a string enum.
+ */
+export function IsStringEnum(entity: Object, validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.IS_IN,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [getEnumStringValues(entity)],
             validationOptions: validationOptions
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,14 @@ export function convertToArray<T>(val: Array<T> | Set<T> | Map<any, T>): Array<T
     }
     return Array.isArray(val) ? val : Array.from(val);
 }
+
+/**
+ * Get values of an Enum
+ */
+export const getEnumStringValues = <T extends any>(SomeEnum: Record<string, T>): T[] => {
+    const enumValues: Array<T> = [];
+    for (const value in SomeEnum) {
+        if (typeof SomeEnum[value] !== "number") enumValues.push(SomeEnum[value]);
+    }
+    return enumValues;
+};

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -24,6 +24,7 @@ import {
     IsDivisibleBy,
     IsEmail,
     IsEnum,
+    IsStringEnum,
     IsFQDN,
     IsFullWidth,
     IsHalfWidth,
@@ -880,6 +881,70 @@ describe("IsEnum", function() {
 
 });
 
+describe("IsStringEnum", function() {
+
+    enum MyRegularEnum {
+        First,
+        Second
+    }
+
+    enum MyStringEnum {
+        First   = "first",
+        Second  = "second"
+    }
+
+    const validRegularValues = ["First", "Second"];
+    const stringConstraint = ["first", "second"];
+    const validStringValues = [MyStringEnum.First, MyStringEnum.Second];
+    const invalidValues = [
+        true,
+        false,
+        0,
+        {},
+        null,
+        undefined,
+        "F2irst"
+    ];
+
+    class MyClass {
+        @IsStringEnum(MyRegularEnum)
+        someProperty: MyRegularEnum;
+    }
+
+    class MyClass2 {
+        @IsStringEnum(MyStringEnum)
+        someProperty: MyStringEnum;
+    }
+
+    it("should not fail if validator.validate said that its valid", function(done) {
+        checkValidValues(new MyClass(), validRegularValues, done);
+    });
+
+    it("should not fail if validator.validate said that its valid (string enum)", function(done) {
+        checkValidValues(new MyClass2(), validStringValues, done);
+    });
+
+    it("should fail if validator.validate said that its invalid", function(done) {
+        checkInvalidValues(new MyClass(), invalidValues, done);
+    });
+
+    it("should fail if validator.validate said that its invalid (string enum)", function(done) {
+        checkInvalidValues(new MyClass2(), invalidValues, done);
+    });
+
+    it("should return error object with proper data", function(done) {
+        const validationType = "isIn";
+        const message = "someProperty must be one of the following values: " + validRegularValues;
+        checkReturnedError(new MyClass(), invalidValues, validationType, message, done);
+    });
+
+    it("should return error object with proper data (string enum)", function(done) {
+        const validationType = "isIn";
+        const message = "someProperty must be one of the following values: " + stringConstraint;
+        checkReturnedError(new MyClass2(), invalidValues, validationType, message, done);
+    });
+
+});
 
 // -------------------------------------------------------------------------
 // Specifications: number check

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -471,7 +471,7 @@ describe("IsLatLong", function () {
 
     it("should fail if validator.validate said that its invalid", function (done) {
         checkInvalidValues(new MyClass(), invalidValues, done);
-    }); 
+    });
 
 });
 describe("IsLatitude", function () {
@@ -3281,19 +3281,19 @@ describe("isHash", function() {
         it("should not fail if validator.validate said that its valid", function(done) {
             checkValidValues(new MyClass(), validValues, done);
         });
-    
+
         it("should fail if validator.validate said that its invalid", function(done) {
             checkInvalidValues(new MyClass(), invalidValues, done);
         });
-    
+
         it("should not fail if method in validator said that its valid", function() {
             validValues.forEach(value => validator.isHash(value, algorithm).should.be.true);
         });
-    
+
         it("should fail if method in validator said that its invalid", function() {
             invalidValues.forEach(value => validator.isHash(value, algorithm).should.be.false);
         });
-    
+
         it("should return error object with proper data", function(done) {
             const validationType = "isHash";
             const message = `someProperty must be a hash of type ${algorithm}`;
@@ -3354,7 +3354,7 @@ describe("isHash", function() {
            "39485729348",
            "%&FHKJFvk",
          ];
-    
+
          testHash(algorithm, validValues, invalidValues);
     });
 
@@ -3373,7 +3373,7 @@ describe("isHash", function() {
            "39485729348",
            "%&FHKJFvk",
          ];
-    
+
          testHash(algorithm, validValues, invalidValues);
         });
 
@@ -3392,7 +3392,7 @@ describe("isHash", function() {
             "39485729348",
             "%&FHKJFvk",
             ];
-    
+
             testHash(algorithm, validValues, invalidValues);
         });
 
@@ -3411,7 +3411,7 @@ describe("isHash", function() {
             "39485729348",
             "%&FHKJFvk",
             ];
-    
+
             testHash(algorithm, validValues, invalidValues);
         });
 
@@ -3430,9 +3430,9 @@ describe("isHash", function() {
             "39485729348",
             "%&FHKJFvk",
             ];
-    
+
             testHash(algorithm, validValues, invalidValues);
-        });  
+        });
 });
 
 describe("IsISSN", function() {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -3,7 +3,7 @@ import "es6-shim";
 import { should, use } from "chai";
 
 import * as chaiAsPromised from "chai-as-promised";
-import { convertToArray } from "../src/utils";
+import { convertToArray, getEnumStringValues } from "../src/utils";
 
 should();
 use(chaiAsPromised);
@@ -57,6 +57,33 @@ describe("utils", function () {
             arr.length.should.be.equal(2);
             arr.should.contains("hello");
             arr.should.contains("world");
+        });
+
+    });
+
+    describe("getEnumStringValues", function () {
+
+        it("gets the values of a string enum", function () {
+            enum stringEnum {
+                first = "firstValue",
+                second = "secondValue"
+            }
+            const stringEnumValues = getEnumStringValues(stringEnum);
+            stringEnumValues.length.should.be.equal(2);
+            stringEnumValues.should.contains("firstValue");
+            stringEnumValues.should.contains("secondValue");
+        });
+
+        it("gets the values of a regular enum", function () {
+            enum regularEnum {
+                zero,
+                one
+            }
+            const regularEnumValues = getEnumStringValues(regularEnum);
+            console.log("regularEnumValues", regularEnumValues);
+            regularEnumValues.length.should.be.equal(2);
+            regularEnumValues.should.contains("zero");
+            regularEnumValues.should.contains("one");
         });
 
     });


### PR DESCRIPTION
Feature request:
The @IsEnum does not show the possible values during validation, it says "someProperty must be a valid enum value".
When all the values of an enum are strings we could display something similar to the @IsIn decorator.