### PR TITLE
fix: switch isLatitude & isLongitude validators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "class-validator",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -281,7 +281,7 @@ export function IsLatLong(validationOptions?: ValidationOptions) {
 export function IsLatitude(validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
-            type: ValidationTypes.IS_LONGITUDE,
+            type: ValidationTypes.IS_LATITUDE,
             target: object.constructor,
             propertyName: propertyName,
             validationOptions: validationOptions
@@ -296,7 +296,7 @@ export function IsLatitude(validationOptions?: ValidationOptions) {
 export function IsLongitude(validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
-            type: ValidationTypes.IS_LATITUDE,
+            type: ValidationTypes.IS_LONGITUDE,
             target: object.constructor,
             propertyName: propertyName,
             validationOptions: validationOptions


### PR DESCRIPTION
Hey guys,

I was looking where these functions come from as from `validator.js` they don't exist, but I found out the type between them was inverted.

Tests are ok when changing those. Maybe I can add a few more to be sure it won't happen again?