### PR TITLE
docs: remove extra "/" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ class User extends BaseContent {
     welcome: string;
 
     @MinLength(20)
-    password: string; /
+    password: string;
 }
 
 let user = new User();


### PR DESCRIPTION
I think it's a mistake.