### PR TITLE
feat: add NotMatches validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ validator.length(str, min, max); // Checks if the string's length falls in a ran
 validator.minLength(str, min); // Checks if the string's length is not less than given number.
 validator.maxLength(str, max); // Checks if the string's length is not more than given number.
 validator.matches(str, pattern, modifiers); // Checks if string matches the pattern. Either matches('foo', /foo/i) or matches('foo', 'foo', 'i').
+validator.notMatches(str, pattern, modifiers); // Checks if string doesn't matches the pattern. Either notMatches('foo', /foo/i) or notMatches('foo', 'foo', 'i').
 validator.isMilitaryTime(str); // Checks if the string is a valid representation of military time in the format HH:MM.
 validator.isHash(str, algorithm); // Checks if the string is a hash of type algorithm.
 validator.isISSN(str, options); // Checks if the string is a ISSN.
@@ -956,6 +957,7 @@ validator.isInstance(value, target); // Checks value is an instance of the targe
 | `@MinLength(min: number)`                       | Checks if the string's length is not less than given number.                                                                     |
 | `@MaxLength(max: number)`                       | Checks if the string's length is not more than given number.                                                                     |
 | `@Matches(pattern: RegExp, modifiers?: string)` | Checks if string matches the pattern. Either matches('foo', /foo/i) or matches('foo', 'foo', 'i').
+| `@NotMatches(pattern: RegExp, modifiers?: string)` | Checks if string doesn't matches the pattern. Either notMatches('foo', /foo/i) or notMatches('foo', 'foo', 'i').
 | `@IsMilitaryTime()`                             | Checks if the string is a valid representation of military time in the format HH:MM.                                         |
 | `@IsHash(algorithm: string)`                    | Checks if the string is a hash of type algorithm. <br/><br/>Algorithm is one of `['md4', 'md5', 'sha1', 'sha256', 'sha384', 'sha512', 'ripemd128', 'ripemd160', 'tiger128', 'tiger160', 'tiger192', 'crc32', 'crc32b']`                                                                                 |
 | `@IsISSN(options?: IsISSNOptions)`              | Checks if the string is a ISSN.                                                                                                  |

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -1234,6 +1234,32 @@ export function Matches(pattern: RegExp, modifiersOrAnnotationOptions?: string|V
 }
 
 /**
+ * Checks if string doesn't matches the pattern. Either notMatches('foo', /foo/i) or notMatches('foo', 'foo', 'i').
+ */
+export function NotMatches(pattern: RegExp, validationOptions?: ValidationOptions): Function;
+export function NotMatches(pattern: RegExp, modifiers?: string, validationOptions?: ValidationOptions): Function;
+export function NotMatches(pattern: RegExp, modifiersOrAnnotationOptions?: string|ValidationOptions, validationOptions?: ValidationOptions): Function {
+    
+    let modifiers: string;
+    if (modifiersOrAnnotationOptions && modifiersOrAnnotationOptions instanceof Object && !validationOptions) {
+        validationOptions = modifiersOrAnnotationOptions as ValidationOptions;
+    } else {
+        modifiers = modifiersOrAnnotationOptions as string;
+    }
+
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.NOTMATCHES,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [pattern, modifiers],
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
+/**
  * Checks if the string correctly represents a time in the format HH:MM
  */
 export function IsMilitaryTime(validationOptions?: ValidationOptions) {

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -92,6 +92,7 @@ export class ValidationTypes {
     static MIN_LENGTH = "minLength";
     static MAX_LENGTH = "maxLength";
     static MATCHES = "matches";
+    static NOTMATCHES = "notMatches";
     static IS_MILITARY_TIME = "isMilitaryTime";
     static IS_HASH = "isHash";
     static IS_ISSN = "isISSN";
@@ -284,6 +285,8 @@ export class ValidationTypes {
                 return eachPrefix + "$property must be shorter than or equal to $constraint1 characters";
             case this.MATCHES:
                 return eachPrefix + "$property must match $constraint1 regular expression";
+            case this.NOTMATCHES:
+                return eachPrefix + "$property must not match $constraint1 regular expression";
             case this.IS_MILITARY_TIME:
                 return eachPrefix + "$property must be a valid representation of military time in the format HH:MM";
             case this.IS_HASH:

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -268,6 +268,8 @@ export class Validator {
                 return this.maxLength(value, metadata.constraints[0]);
             case ValidationTypes.MATCHES:
                 return this.matches(value, metadata.constraints[0], metadata.constraints[1]);
+            case ValidationTypes.NOTMATCHES:
+                return this.notMatches(value, metadata.constraints[0], metadata.constraints[1]);
             case ValidationTypes.IS_MILITARY_TIME:
                 return this.isMilitaryTime(value);
             case ValidationTypes.IS_HASH:
@@ -881,6 +883,14 @@ export class Validator {
      */
     matches(value: unknown, pattern: RegExp, modifiers?: string): boolean {
         return typeof value === "string" && this.validatorJs.matches(value, pattern, modifiers);
+    }
+
+    /**
+     * Checks if string doesn't matches the pattern. Either notMatches('foo', /foo/i) or notMatches('foo', 'foo', 'i').
+     * If given value is not a string, then it returns false.
+     */
+    notMatches(value: unknown, pattern: RegExp, modifiers?: string): boolean {
+        return typeof value === "string" && !this.validatorJs.matches(value, pattern, modifiers);
     }
 
     /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -49,6 +49,7 @@ import {
     IsUUID,
     IsUppercase,
     Matches,
+    NotMatches,
     MinLength,
     MaxLength,
     Min,
@@ -3152,6 +3153,41 @@ describe("Matches", function() {
     it("should return error object with proper data", function(done) {
         const validationType = "matches";
         const message = "someProperty must match " + constraint + " regular expression";
+        checkReturnedError(new MyClass(), invalidValues, validationType, message, done);
+    });
+
+});
+
+describe("NotMatches", function() {
+
+    const constraint = /abc/;
+    const validValues = ["acb", "Abc"];
+    const invalidValues = [null, undefined, "abc", "abcdef", "123abc"];
+
+    class MyClass {
+        @NotMatches(constraint)
+        someProperty: string;
+    }
+
+    it("should not fail if validator.validate said that its valid", function(done) {
+        checkValidValues(new MyClass(), validValues, done);
+    });
+
+    it("should fail if validator.validate said that its invalid", function(done) {
+        checkInvalidValues(new MyClass(), invalidValues, done);
+    });
+
+    it("should not fail if method in validator said that its valid", function() {
+        validValues.forEach(value => (!validator.matches(value, constraint)).should.be.true);
+    });
+
+    it("should fail if method in validator said that its invalid", function() {
+        invalidValues.forEach(value => (typeof value === "string" && (!validator.matches(value, constraint))).should.be.false);
+    });
+
+    it("should return error object with proper data", function(done) {
+        const validationType = "notMatches";
+        const message = "someProperty must not match " + constraint + " regular expression";
         checkReturnedError(new MyClass(), invalidValues, validationType, message, done);
     });
 


### PR DESCRIPTION
Hello, this should add a NotMatches decorator as suggested in issue #331 

* [x] Documentation (Validator and Manual validation)
* [x] Validator and Decorator
* [x] Default validation error message
* [x] Tests

Have a good day