### PR TITLE
feat: add partials support for nested

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,27 @@ When skipping missing properties, sometimes you want not to skip all missing pro
 for you, even if skipMissingProperties is set to true. For such cases you should use `@IsDefined()` decorator.
 `@IsDefined()` is the only decorator that ignores `skipMissingProperties` option.
 
+You can also do this for your nested objects like this:
+```typescript
+export class Post {
+    @ValidateNested({ partial: true })
+    @Type(() => Content)
+    content: Partial<Content>
+
+    @IsNumber()
+    ownerId: number
+}
+
+export class Content {
+    @IsString()
+    @MaxLengh(1000)
+    text: string
+    
+    @IsUrl()
+    image: string
+}
+```
+
 ## Validation groups
 
 In different situations you may want to use different validation schemas of the same object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "class-validator",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/decorator/ValidationOptions.ts
+++ b/src/decorator/ValidationOptions.ts
@@ -11,6 +11,11 @@ export interface ValidationOptions {
     each?: boolean;
 
     /**
+     * Specifies if validated value should be validated as Partial<T> (e.g. skipping missing properties)
+     */
+    partial?: boolean;
+
+    /**
      * Error message used to be used on validation fail.
      * Message can be either string, either a function that returns a string.
      */

--- a/src/metadata/ValidationMetadata.ts
+++ b/src/metadata/ValidationMetadata.ts
@@ -55,6 +55,11 @@ export class ValidationMetadata {
      */
     each: boolean = false;
 
+    /**
+     * Specifies if validated value should be validated as Partial<T> (e.g. skipping missing properties)
+     */
+    partial?: boolean;
+
     /*
      * A transient set of data passed through to the validation result for response mapping
      */
@@ -81,6 +86,7 @@ export class ValidationMetadata {
             this.groups = args.validationOptions.groups;
             this.always = args.validationOptions.always;
             this.each = args.validationOptions.each;
+            this.partial = args.validationOptions.partial;
             this.context = args.validationOptions.context;
         }
     }


### PR DESCRIPTION
so basically implemented #528 --  nesteds can now be validated as partials:
```typescript
export class Post {
    @ValidateNested({ partial: true })
    content: Partial<Content>

    @IsNumber()
    ownerId: number
}
export class Content {
    @IsString()
    @MaxLengh(1000)
    text: string
    
    @IsUrl()
    image: string
}

const post = new Post()
post.ownerId = 42
post.content = new Content()
post.content.text = 'ok'

validate(post) // ok
```

not quite sure whether what i have done is the best way of achieving this, but at least it seems to work.