### PR TITLE
fix: switch isLatitude & isLongitude validators

### DIFF
--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -371,14 +371,14 @@ export class Validator {
     * Checks if a given value is a latitude.
     */
     isLatitude(value: unknown): boolean {
-        return (typeof value === "number" || this.isString(value)) && this.isLatLong(`0,${value}`);
+        return (typeof value === "number" || this.isString(value)) && this.isLatLong(`${value},0`);
     }
 
     /**
     * Checks if a given value is a longitude.
     */
     isLongitude(value: unknown): boolean {
-        return (typeof value === "number" || this.isString(value)) && this.isLatLong(`${value},0`);
+        return (typeof value === "number" || this.isString(value)) && this.isLatLong(`0,${value}`);
     }
 
     /**


### PR DESCRIPTION
Validatorjs check if the string is a valid latitude-longitude coordinate in the format lat,long or lat, long.

Ref: https://github.com/validatorjs/validator.js