### PR TITLE
feat: add support for conditional nested validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,23 @@ export class Plan2D {
 }
 ```
 
+If your property only requires nested validation in some cases (e.g. the property can be one of several different types), you can conditionally validate nested:
+
+```typescript
+import {ValidateNestedIf, MinLength} from "class-validator";
+
+export class User {
+    @MinLength(5)
+    name: String;
+}
+
+export class Post {
+
+    @ValidateNestedIf((object, value) => value instanceof User)
+    user: String | User;
+}
+```
+
 ## Validating promises
 
 If your object contains property with `Promise`-returned value that should be validated, then you need to use the `@ValidatePromise()` decorator:

--- a/src/decorator/common/ValidateNested.ts
+++ b/src/decorator/common/ValidateNested.ts
@@ -1,8 +1,8 @@
-import { ValidationOptions } from "../ValidationOptions";
+import { getMetadataStorage } from "../../metadata/MetadataStorage";
+import { ValidationMetadata } from "../../metadata/ValidationMetadata";
 import { ValidationMetadataArgs } from "../../metadata/ValidationMetadataArgs";
 import { ValidationTypes } from "../../validation/ValidationTypes";
-import { ValidationMetadata } from "../../metadata/ValidationMetadata";
-import { getMetadataStorage } from "../../metadata/MetadataStorage";
+import { ValidationOptions } from "../ValidationOptions";
 
 /**
  * Objects / object arrays marked with this decorator will also be validated.
@@ -17,6 +17,23 @@ export function ValidateNested(validationOptions?: ValidationOptions): PropertyD
             type: ValidationTypes.NESTED_VALIDATION,
             target: object.constructor,
             propertyName: propertyName,
+            validationOptions: opts,
+        };
+        getMetadataStorage().addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
+export function ValidateNestedIf(condition: (object: any, value: any) => boolean, validationOptions?: ValidationOptions): PropertyDecorator {
+    const opts: ValidationOptions = { ...validationOptions };
+    const eachPrefix = opts.each ? "each value in " : "";
+    opts.message = opts.message || eachPrefix + "nested property $property must be either object or array";
+
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.NESTED_VALIDATION,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [condition],
             validationOptions: opts,
         };
         getMetadataStorage().addValidationMetadata(new ValidationMetadata(args));

--- a/src/register-decorator.ts
+++ b/src/register-decorator.ts
@@ -1,12 +1,12 @@
-import {ConstraintMetadata} from "./metadata/ConstraintMetadata";
-import {ValidatorConstraintInterface} from "./validation/ValidatorConstraintInterface";
-import {ValidationMetadata} from "./metadata/ValidationMetadata";
-import {ValidationMetadataArgs} from "./metadata/ValidationMetadataArgs";
-import {ValidationTypes} from "./validation/ValidationTypes";
-import {ValidationArguments} from "./validation/ValidationArguments";
 import { getFromContainer } from "./container";
-import { MetadataStorage, getMetadataStorage } from "./metadata/MetadataStorage";
 import { ValidationOptions } from "./decorator/ValidationOptions";
+import { ConstraintMetadata } from "./metadata/ConstraintMetadata";
+import { getMetadataStorage, MetadataStorage } from "./metadata/MetadataStorage";
+import { ValidationMetadata } from "./metadata/ValidationMetadata";
+import { ValidationMetadataArgs } from "./metadata/ValidationMetadataArgs";
+import { ValidationArguments } from "./validation/ValidationArguments";
+import { ValidationTypes } from "./validation/ValidationTypes";
+import { ValidatorConstraintInterface } from "./validation/ValidatorConstraintInterface";
 
 export interface ValidationDecoratorOptions {
 

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -1,13 +1,13 @@
-import {Validator} from "./Validator";
-import {ValidationError} from "./ValidationError";
-import {ValidationMetadata} from "../metadata/ValidationMetadata";
-import {ValidatorOptions} from "./ValidatorOptions";
-import {ValidationTypes} from "./ValidationTypes";
-import {ConstraintMetadata} from "../metadata/ConstraintMetadata";
-import {ValidationArguments} from "./ValidationArguments";
-import {ValidationUtils} from "./ValidationUtils";
-import {isPromise, convertToArray} from "../utils";
+import { ConstraintMetadata } from "../metadata/ConstraintMetadata";
 import { getMetadataStorage } from "../metadata/MetadataStorage";
+import { ValidationMetadata } from "../metadata/ValidationMetadata";
+import { convertToArray, isPromise } from "../utils";
+import { ValidationArguments } from "./ValidationArguments";
+import { ValidationError } from "./ValidationError";
+import { ValidationTypes } from "./ValidationTypes";
+import { ValidationUtils } from "./ValidationUtils";
+import { Validator } from "./Validator";
+import { ValidatorOptions } from "./ValidatorOptions";
 
 /**
  * Executes validation over given object.
@@ -182,7 +182,11 @@ export class ValidationExecutor {
         }
 
         this.customValidations(object, value, customValidationMetadatas, validationError);
-        this.nestedValidations(value, nestedValidationMetadatas, validationError.children);
+
+        const canValidateNested = this.conditionalValidations(object, value, nestedValidationMetadatas);
+        if (canValidateNested) {
+            this.nestedValidations(value, nestedValidationMetadatas, validationError.children);
+        }
 
         this.mapContexts(object, value, metadatas, validationError);
         this.mapContexts(object, value, customValidationMetadatas, validationError);
@@ -214,7 +218,7 @@ export class ValidationExecutor {
                                    value: any,
                                    metadatas: ValidationMetadata[]) {
         return metadatas
-            .map(metadata => metadata.constraints[0](object, value))
+            .map(metadata => !metadata.constraints || metadata.constraints[0](object, value))
             .reduce((resultA, resultB) => resultA && resultB, true);
     }
 

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -329,10 +329,7 @@ describe("nested validation", function () {
         }
 
         class MyClass {
-            @ValidateNestedIf((_, value: any) => {
-                console.log(value);
-                return value instanceof MySubClass;
-            })
+            @ValidateNestedIf((_, value: any) => value instanceof MySubClass)
             mySubClass: String | MySubClass;
         }
 


### PR DESCRIPTION
I have a configuration syntax that my users use to configure our platform, and was frequently running into cases where I wanted to conditionally validate a nested object (we frequently support a shorthand syntax for `<property>.default = <default-value>` as `<property> = <default-value>` when the user doesn't intend to use the rest of the nested config block). The suggestion to use "groups" from https://github.com/typestack/class-validator/issues/278 seemed insufficient since it requires me to explicitly choose which groups to validate against when really I just want the users input to guide the validation. The changes here would allow for a new validator, `@ValidateNestedIf()` that would only trigger nested validation upon the passing of the embedded condition.