### PR TITLE
docs: fix typos across repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@
 * updated [validator.js][validator-js] from 9.2.0 to 10.4.0 (Check it's [changelog][validator-js-release-notes] for what has changed.)
   * until now fractional numbers was not allowed in the `IsNumberString` decorator, now they are allowed
   * until now Gmail addresses could contain multiple dots or random text after a `+` symbol, this is not allowed anymore 
-* `IsPhoneNumber` decorator has been added which uses the [google-libphonenumber][google-libphonenumber] libary to validate international phone numbers accurately
+* `IsPhoneNumber` decorator has been added which uses the [google-libphonenumber][google-libphonenumber] library to validate international phone numbers accurately
 
 ### Bug Fixes
 

--- a/src/metadata/MetadataStorage.ts
+++ b/src/metadata/MetadataStorage.ts
@@ -77,7 +77,7 @@ export class MetadataStorage {
 
         // get metadatas for inherited classes
         const inheritedMetadatas = this.validationMetadatas.filter(metadata => {
-            // if target is a string it's means we validate agains a schema, and there is no inheritance support for schemas
+            // if target is a string it's means we validate against a schema, and there is no inheritance support for schemas
             if (typeof metadata.target === "string")
                 return false;
             if (metadata.target === targetConstructor)


### PR DESCRIPTION
Files that have typos:

```
src/metadata/MetadataStorage.ts:80:60: corrected "agains" to "against"
CHANGELOG.md:181:105: corrected "libary" to "library"
```
**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos