### PR TITLE
feat: add option to stop validation at first error

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ export interface ValidatorOptions {
   };
 
   forbidUnknownValues?: boolean;
+  stopAtFirstError?: boolean;
 }
 ```
 

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -238,7 +238,12 @@ export class ValidationExecutor {
     metadatas.forEach(metadata => {
       this.metadataStorage.getTargetValidatorConstraints(metadata.constraintCls).forEach(customConstraintMetadata => {
         if (customConstraintMetadata.async && this.ignoreAsyncValidations) return;
-        if (this.validatorOptions && this.validatorOptions.stopAtFirstError && Object.keys(error.constraints || {}).length > 0) return;
+        if (
+          this.validatorOptions &&
+          this.validatorOptions.stopAtFirstError &&
+          Object.keys(error.constraints || {}).length > 0
+        )
+          return;
 
         const validationArguments: ValidationArguments = {
           targetName: object.constructor ? (object.constructor as any).name : undefined,
@@ -334,7 +339,6 @@ export class ValidationExecutor {
         const arrayLikeValue = value instanceof Set ? Array.from(value) : value;
         arrayLikeValue.forEach((subValue: any, index: any) => {
           this.performValidations(value, subValue, index.toString(), [], metadatas, errors);
-
         });
       } else if (value instanceof Object) {
         const targetSchema = typeof metadata.target === 'string' ? metadata.target : metadata.target.name;

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -238,6 +238,7 @@ export class ValidationExecutor {
     metadatas.forEach(metadata => {
       this.metadataStorage.getTargetValidatorConstraints(metadata.constraintCls).forEach(customConstraintMetadata => {
         if (customConstraintMetadata.async && this.ignoreAsyncValidations) return;
+        if (this.validatorOptions && this.validatorOptions.stopAtFirstError && Object.keys(error.constraints || {}).length > 0) return;
 
         const validationArguments: ValidationArguments = {
           targetName: object.constructor ? (object.constructor as any).name : undefined,
@@ -333,6 +334,7 @@ export class ValidationExecutor {
         const arrayLikeValue = value instanceof Set ? Array.from(value) : value;
         arrayLikeValue.forEach((subValue: any, index: any) => {
           this.performValidations(value, subValue, index.toString(), [], metadatas, errors);
+
         });
       } else if (value instanceof Object) {
         const targetSchema = typeof metadata.target === 'string' ? metadata.target : metadata.target.name;

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -59,4 +59,9 @@ export interface ValidatorOptions {
    * Settings true will cause fail validation of unknown objects.
    */
   forbidUnknownValues?: boolean;
+
+  /**
+   * Settings true will stop validation when encount first error.
+   */
+  stopAtFirstError?: boolean;
 }

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -61,7 +61,7 @@ export interface ValidatorOptions {
   forbidUnknownValues?: boolean;
 
   /**
-   * Settings true will stop validation when encount first error.
+   * When set to true, validation of the given property will stop after encountering the first error. Defaults to false.
    */
   stopAtFirstError?: boolean;
 }

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1090,10 +1090,10 @@ describe('context', () => {
   it('should stop at first error.', () => {
     class MyClass {
       @IsDefined({
-        message: 'isDefined'
+        message: 'isDefined',
       })
       @Contains('hello', {
-        message: 'String is not valid. You string must contain a hello word'
+        message: 'String is not valid. You string must contain a hello word',
       })
       sameProperty: string;
     }

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1087,29 +1087,29 @@ describe('context', () => {
     });
   });
 
-  it("should stop at first error.", () => {
+  it('should stop at first error.', () => {
     class MyClass {
       @IsDefined({
-        message: "isDefined",
+        message: 'isDefined',
         context: {
-          bye: "now"
-        }
+          bye: 'now',
+        },
       })
-      @Contains("hello", {
-        message: "String is not valid. You string must contain a hello word",
+      @Contains('hello', {
+        message: 'String is not valid. You string must contain a hello word',
         context: {
-          bye: "now"
-        }
+          bye: 'now',
+        },
       })
       sameProperty: string;
     }
 
     const model = new MyClass();
-    return validator.validate(model, {stopAtFirstError: true}).then(errors => {
+    return validator.validate(model, { stopAtFirstError: true }).then(errors => {
       expect(errors.length).toEqual(1);
       expect(Object.keys(errors[0].constraints).length).toBe(1);
-      expect(errors[0].contexts["isDefined"]).toEqual({bye: "now"});
-      expect(errors[0].constraints["isDefined"]).toBe("isDefined");
+      expect(errors[0].contexts['isDefined']).toEqual({ bye: 'now' });
+      expect(errors[0].constraints['isDefined']).toBe('isDefined');
     });
   });
 });

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1086,4 +1086,30 @@ describe('context', () => {
       expect(errors[1].contexts['contains']).toEqual({ bye: 'now' });
     });
   });
+
+  it("should stop at first error.", () => {
+    class MyClass {
+      @IsDefined({
+        message: "isDefined",
+        context: {
+          bye: "now"
+        }
+      })
+      @Contains("hello", {
+        message: "String is not valid. You string must contain a hello word",
+        context: {
+          bye: "now"
+        }
+      })
+      sameProperty: string;
+    }
+
+    const model = new MyClass();
+    return validator.validate(model, {stopAtFirstError: true}).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(Object.keys(errors[0].constraints).length).toBe(1);
+      expect(errors[0].contexts["isDefined"]).toEqual({bye: "now"});
+      expect(errors[0].constraints["isDefined"]).toBe("isDefined");
+    });
+  });
 });

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1090,25 +1090,19 @@ describe('context', () => {
   it('should stop at first error.', () => {
     class MyClass {
       @IsDefined({
-        message: 'isDefined',
-        context: {
-          bye: 'now',
-        },
+        message: 'isDefined'
       })
       @Contains('hello', {
-        message: 'String is not valid. You string must contain a hello word',
-        context: {
-          bye: 'now',
-        },
+        message: 'String is not valid. You string must contain a hello word'
       })
       sameProperty: string;
     }
 
     const model = new MyClass();
     return validator.validate(model, { stopAtFirstError: true }).then(errors => {
+      console.log();
       expect(errors.length).toEqual(1);
       expect(Object.keys(errors[0].constraints).length).toBe(1);
-      expect(errors[0].contexts['isDefined']).toEqual({ bye: 'now' });
       expect(errors[0].constraints['isDefined']).toBe('isDefined');
     });
   });


### PR DESCRIPTION
## Description

Added an option to not detect more than one Error for each item.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes (An error occurs outside of this PR.)
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->

references #148, references #399, references #188
