### PR TITLE
fix: allow "any" as locale in isPostalCode decorator

### DIFF
--- a/src/decorator/string/IsPostalCode.ts
+++ b/src/decorator/string/IsPostalCode.ts
@@ -10,7 +10,7 @@ export const IS_POSTAL_CODE = 'isPostalCode';
  * (locale is one of [ 'AD', 'AT', 'AU', 'BE', 'BG', 'BR', 'CA', 'CH', 'CZ', 'DE', 'DK', 'DZ', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'ID', 'IE' 'IL', 'IN', 'IR', 'IS', 'IT', 'JP', 'KE', 'LI', 'LT', 'LU', 'LV', 'MT', 'MX', 'NL', 'NO', 'NZ', 'PL', 'PR', 'PT', 'RO', 'RU', 'SA', 'SE', 'SI', 'TN', 'TW', 'UA', 'US', 'ZA', 'ZM' ] OR 'any'. If 'any' is used, function will check if any of the locals match. Locale list is validator.isPostalCodeLocales.).
  * If given value is not a string, then it returns false.
  */
-export function isPostalCode(value: unknown, locale: ValidatorJS.PostalCodeLocale): boolean {
+export function isPostalCode(value: unknown, locale: 'any' | ValidatorJS.PostalCodeLocale): boolean {
   return typeof value === 'string' && isPostalCodeValidator(value, locale);
 }
 
@@ -20,7 +20,7 @@ export function isPostalCode(value: unknown, locale: ValidatorJS.PostalCodeLocal
  * If given value is not a string, then it returns false.
  */
 export function IsPostalCode(
-  locale?: ValidatorJS.PostalCodeLocale,
+  locale?: 'any' | ValidatorJS.PostalCodeLocale,
   validationOptions?: ValidationOptions
 ): PropertyDecorator {
   return ValidateBy(


### PR DESCRIPTION
PostalCodeLocale in @types/validator.js does not include 'any' but isPostalCode should be able to receive it as a locale

[PostalCodeLocale in @types/validator.js ](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/80922190a8125f052351520d07cb5166fc9b917b/types/validator/index.d.ts#L957)