### PR TITLE
Fix/accept unknown types

### DIFF
--- a/src/decorator/common/IsLatLong.ts
+++ b/src/decorator/common/IsLatLong.ts
@@ -7,7 +7,7 @@ export const IS_LATLONG = "isLatLong";
 /**
  * Checks if a value is string in format a "latitude,longitude".
  */
-export function isLatLong(value: string): boolean {
+export function isLatLong(value: unknown): boolean {
     return typeof value === "string" && validator.isLatLong(value);
 }
 

--- a/src/decorator/common/IsLatitude.ts
+++ b/src/decorator/common/IsLatitude.ts
@@ -7,7 +7,7 @@ export const IS_LATITUDE = "isLatitude";
 /**
  * Checks if a given value is a latitude.
  */
-export function isLatitude(value: string): boolean {
+export function isLatitude(value: unknown): boolean {
     return (typeof value === "number" || typeof value === "string") && isLatLong(`${value},0`);
 }
 

--- a/src/decorator/common/IsLongitude.ts
+++ b/src/decorator/common/IsLongitude.ts
@@ -7,7 +7,7 @@ export const IS_LONGITUDE = "isLongitude";
 /**
  * Checks if a given value is a longitude.
  */
-export function isLongitude(value: string): boolean {
+export function isLongitude(value: unknown): boolean {
     return (typeof value === "number" || typeof value === "string") && isLatLong(`0,${value}`);
 }
 

--- a/src/decorator/string/IsUrl.ts
+++ b/src/decorator/string/IsUrl.ts
@@ -8,7 +8,7 @@ export const IS_URL = "isUrl";
  * Checks if the string is an url.
  * If given value is not a string, then it returns false.
  */
-export function isURL(value: string, options?: ValidatorJS.IsURLOptions): boolean {
+export function isURL(value: unknown, options?: ValidatorJS.IsURLOptions): boolean {
     return typeof value === "string" && ValidatorJS.isURL(value, options);
 }
 

--- a/src/decorator/string/Matches.ts
+++ b/src/decorator/string/Matches.ts
@@ -8,9 +8,9 @@ export const MATCHES = "matches";
  * Checks if string matches the pattern. Either matches('foo', /foo/i).
  * If given value is not a string, then it returns false.
  */
-export function matches(value: string, pattern: RegExp): boolean;
-export function matches(value: string, pattern: string, modifiers: string): boolean;
-export function matches(value: string, pattern: RegExp | string, modifiers?: string): boolean {
+export function matches(value: unknown, pattern: RegExp): boolean;
+export function matches(value: unknown, pattern: string, modifiers: string): boolean;
+export function matches(value: unknown, pattern: RegExp | string, modifiers?: string): boolean {
     return typeof value === "string" && validator.matches(value, pattern as unknown as any, modifiers);
 }
 


### PR DESCRIPTION
I'm helped by this product a lot.

Some validation methods accepted only limited types, but I think it should accept unknown types like `isEmail`.
(Confirmed to pass existing test.)

https://github.com/typestack/class-validator/blob/1955250de64d76504df465aa02076a2e5b219bb7/src/decorator/string/IsEmail.ts#L11-L13