### PR TITLE
fix: alias IsDateString() decorator to IsISO8601()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Class-validator works on both browser and node.js platforms.
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Usage](#usage)
+- [class-validator](#class-validator)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Passing options](#passing-options)
   - [Validation errors](#validation-errors)
   - [Validation messages](#validation-messages)
   - [Validating arrays](#validating-arrays)
@@ -34,9 +37,9 @@ Class-validator works on both browser and node.js platforms.
   - [Validation decorators](#validation-decorators)
   - [Defining validation schema without decorators](#defining-validation-schema-without-decorators)
   - [Validating plain objects](#validating-plain-objects)
-- [Samples](#samples)
-- [Extensions](#extensions)
-- [Release notes](#release-notes)
+  - [Samples](#samples)
+  - [Extensions](#extensions)
+  - [Release notes](#release-notes)
 
 ## Installation
 
@@ -813,7 +816,7 @@ isBoolean(value);
 | `@MaxDate(date: Date)`                          | Checks if the value is a date that's before the specified date.                                                                                                                                                                                                                                                                                                                                                      |  |
 | **String-type validation decorators**           |
 | `@IsBooleanString()`                            | Checks if a string is a boolean (e.g. is "true" or "false").                                                                                                                                                                                                                                                                                                                                                         |
-| `@IsDateString()`                               | Checks if a string is a complete representation of a date (e.g. "2017-06-07T14:34:08.700Z", "2017-06-07T14:34:08.700 or "2017-06-07T14:34:08+04:00").                                                                                                                                                                                                                                                                |
+| `@IsDateString()`                               | Alias for `@IsISO8601()`. Checks if a string is a complete representation of a date (e.g. "2017-06-07T14:34:08.700Z", "2017-06-07T14:34:08.700 or "2017-06-07T14:34:08+04:00").                                                                                                                                                                                                                                      |
 | `@IsNumberString(options?: IsNumericOptions)`   | Checks if a string is a number.                                                                                                                                                                                                                                                                                                                                                                                      |
 | **String validation decorators**                |
 | `@Contains(seed: string)`                       | Checks if the string contains the seed.                                                                                                                                                                                                                                                                                                                                                                              |

--- a/src/decorator/string/IsDateString.ts
+++ b/src/decorator/string/IsDateString.ts
@@ -1,26 +1,34 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
+import ValidatorJS from 'validator';
+import { isISO8601 } from './IsISO8601';
 
 export const IS_DATE_STRING = 'isDateString';
 
 /**
- * Checks if a given value is a ISOString date.
+ * Alias for IsISO8601 validator
  */
-export function isDateString(value: unknown): boolean {
-  const regex = /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-][0-2]\d(?::[0-5]\d)?)?$/g;
-  return typeof value === 'string' && regex.test(value);
+export function isDateString(value: unknown, options?: ValidatorJS.IsISO8601Options): boolean {
+  return isISO8601(value, options);
 }
 
 /**
- * Checks if a given value is a ISOString date.
+ * Alias for IsISO8601 validator
  */
-export function IsDateString(validationOptions?: ValidationOptions): PropertyDecorator {
+export function IsDateString(
+  options?: ValidatorJS.IsISO8601Options,
+  validationOptions?: ValidationOptions
+): PropertyDecorator {
   return ValidateBy(
     {
       name: IS_DATE_STRING,
+      constraints: [options],
       validator: {
         validate: (value, args): boolean => isDateString(value),
-        defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a ISOString', validationOptions),
+        defaultMessage: buildMessage(
+          eachPrefix => eachPrefix + '$property must be a valid ISO 8601 date string',
+          validationOptions
+        ),
       },
     },
     validationOptions

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -789,6 +789,7 @@ describe('IsDateString', () => {
     '2018-01-04T08:15:30+04',
     '2020-03-26T11:00:01-03:00',
     '2020-03-26T11:00:01-03',
+    '2019-09-03T20:16:24.12Z',
   ];
   const invalidValues = [
     true,
@@ -800,6 +801,15 @@ describe('IsDateString', () => {
     'text',
     'text2018-01-04T08:15:30+04',
     '2018-01-04T08:15:30Ztext',
+    '2019-18-13T22:14:14.761Z', // month greater than 12
+    '2019-12-39T22:14:14.761Z', // day greater than 31
+    '2019-12-31T29:14:14.761Z', // hour greater than 24
+    '2019-00-31T29:14:14.761Z', // month of 0
+    '2019-01-00T29:14:14.761Z', // day of 0
+    '2019-09-03T20:16:24.12-5:00', // single digit hour in timezone offset
+    '2019-09-03T20:16:24.12+5:00',
+    '2019-09-03T20:16:24.12-05:0', // single digit minute in timezone offset
+    '2019-09-03T20:16:24.12+05:0',
   ];
 
   class MyClass {
@@ -825,8 +835,7 @@ describe('IsDateString', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isDateString';
-    // const message = "someProperty deve ser um texto de data";
-    const message = 'someProperty must be a ISOString';
+    const message = 'someProperty must be a valid ISO 8601 date string';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });


### PR DESCRIPTION
## Description
`IsDateString()` decorator now aliased to `IsISO8601()` meaning both decorators have the same functionality.

Also added extra tests to make sure IsDateString is parsing ISO8601 dates correctly.

Also added documentation in `README.md` to make clear that the two decorators have same functionality.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #412 
