### PR TITLE
fix: assign `@NestedValidation` error to parent when property is not a class instance

### DIFF
--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -205,7 +205,7 @@ export class ValidationExecutor {
     }
 
     this.customValidations(object, value, customValidationMetadatas, validationError);
-    this.nestedValidations(value, nestedValidationMetadatas, validationError.children);
+    this.nestedValidations(value, nestedValidationMetadatas, validationError);
 
     this.mapContexts(object, value, metadatas, validationError);
     this.mapContexts(object, value, customValidationMetadatas, validationError);
@@ -333,7 +333,7 @@ export class ValidationExecutor {
     });
   }
 
-  private nestedValidations(value: any, metadatas: ValidationMetadata[], errors: ValidationError[]): void {
+  private nestedValidations(value: any, metadatas: ValidationMetadata[], error: ValidationError): void {
     if (value === void 0) {
       return;
     }
@@ -347,21 +347,14 @@ export class ValidationExecutor {
         // Treats Set as an array - as index of Set value is value itself and it is common case to have Object as value
         const arrayLikeValue = value instanceof Set ? Array.from(value) : value;
         arrayLikeValue.forEach((subValue: any, index: any) => {
-          this.performValidations(value, subValue, index.toString(), [], metadatas, errors);
+          this.performValidations(value, subValue, index.toString(), [], metadatas, error.children);
         });
       } else if (value instanceof Object) {
         const targetSchema = typeof metadata.target === 'string' ? metadata.target : metadata.target.name;
-        this.execute(value, targetSchema, errors);
+        this.execute(value, targetSchema, error.children);
       } else {
-        const error = new ValidationError();
-        error.value = value;
-        error.property = metadata.propertyName;
-        error.target = metadata.target as object;
         const [type, message] = this.createValidationError(metadata.target as object, value, metadata);
-        error.constraints = {
-          [type]: message,
-        };
-        errors.push(error);
+        error.constraints[type] = message;
       }
     });
   }

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -341,6 +341,12 @@ export class ValidationExecutor {
     metadatas.forEach(metadata => {
       if (metadata.type !== ValidationTypes.NESTED_VALIDATION && metadata.type !== ValidationTypes.PROMISE_VALIDATION) {
         return;
+      } else if (
+        this.validatorOptions &&
+        this.validatorOptions.stopAtFirstError &&
+        Object.keys(error.constraints || {}).length > 0
+      ) {
+        return;
       }
 
       if (Array.isArray(value) || value instanceof Set || value instanceof Map) {

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -320,11 +320,11 @@ describe('nested validation', () => {
       nestedWithPrimitiveValue: MySubClass;
     }
 
-    const instance = new MyClass();
-    instance.nestedWithClassValue = new MySubClass();
-    instance.nestedWithPrimitiveValue = "invalid" as any;
+    const model = new MyClass();
+    model.nestedWithClassValue = new MySubClass();
+    model.nestedWithPrimitiveValue = "invalid" as any;
 
-    return validator.validate(instance, {stopAtFirstError: true}).then(errors => {
+    return validator.validate(model, {stopAtFirstError: true}).then(errors => {
       expect(errors[0].property).toEqual('nestedWithClassValue');
       expect(errors[0].children.length).toEqual(1);
       expect(errors[0].children[0].constraints).toHaveProperty('minLength');

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -322,9 +322,9 @@ describe('nested validation', () => {
 
     const model = new MyClass();
     model.nestedWithClassValue = new MySubClass();
-    model.nestedWithPrimitiveValue = "invalid" as any;
+    model.nestedWithPrimitiveValue = 'invalid' as any;
 
-    return validator.validate(model, {stopAtFirstError: true}).then(errors => {
+    return validator.validate(model, { stopAtFirstError: true }).then(errors => {
       expect(errors[0].property).toEqual('nestedWithClassValue');
       expect(errors[0].children.length).toEqual(1);
       expect(errors[0].children[0].constraints).toHaveProperty('minLength');

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -163,10 +163,12 @@ describe('nested validation', () => {
     model.mySubClass = 'invalidnested object' as any;
 
     return validator.validate(model).then(errors => {
-        expect(errors[0].target).toEqual(model);
-        expect(errors[0].property).toEqual("mySubClass");
-        expect(errors[0].children.length).toEqual(0);
-        expect(errors[0].constraints).toEqual({[ValidationTypes.NESTED_VALIDATION]: "nested property mySubClass must be either object or array"});
+      expect(errors[0].target).toEqual(model);
+      expect(errors[0].property).toEqual('mySubClass');
+      expect(errors[0].children.length).toEqual(0);
+      expect(errors[0].constraints).toEqual({
+        [ValidationTypes.NESTED_VALIDATION]: 'nested property mySubClass must be either object or array',
+      });
     });
   });
 

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -163,14 +163,10 @@ describe('nested validation', () => {
     model.mySubClass = 'invalidnested object' as any;
 
     return validator.validate(model).then(errors => {
-      expect(errors[0].target).toEqual(model);
-      expect(errors[0].property).toEqual('mySubClass');
-      expect(errors[0].children.length).toEqual(1);
-
-      const subError = errors[0].children[0];
-      expect(subError.constraints).toEqual({
-        [ValidationTypes.NESTED_VALIDATION]: 'nested property mySubClass must be either object or array',
-      });
+        expect(errors[0].target).toEqual(model);
+        expect(errors[0].property).toEqual("mySubClass");
+        expect(errors[0].children.length).toEqual(0);
+        expect(errors[0].constraints).toEqual({[ValidationTypes.NESTED_VALIDATION]: "nested property mySubClass must be either object or array"});
     });
   });
 

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -305,4 +305,31 @@ describe('nested validation', () => {
       expect(subSubError.value).toEqual('my');
     });
   });
+
+  it('nestedValidation should be defined as an error for the property specifying the decorator when validation fails.', () => {
+    class MySubClass {
+      @MinLength(5)
+      name: string;
+    }
+
+    class MyClass {
+      @ValidateNested()
+      nestedWithClassValue: MySubClass;
+
+      @ValidateNested()
+      nestedWithPrimitiveValue: MySubClass;
+    }
+
+    const instance = new MyClass();
+    instance.nestedWithClassValue = new MySubClass();
+    instance.nestedWithPrimitiveValue = "invalid" as any;
+
+    return validator.validate(instance, {stopAtFirstError: true}).then(errors => {
+      expect(errors[0].property).toEqual('nestedWithClassValue');
+      expect(errors[0].children.length).toEqual(1);
+      expect(errors[0].children[0].constraints).toHaveProperty('minLength');
+      expect(errors[1].property).toEqual('nestedWithPrimitiveValue');
+      expect(errors[1].constraints).toHaveProperty('nestedValidation');
+    });
+  });
 });

--- a/test/functional/promise-validation.spec.ts
+++ b/test/functional/promise-validation.spec.ts
@@ -100,7 +100,7 @@ describe('promise validation', () => {
     });
   });
 
-  it('should validate when nested is not object', () => {
+  it("should validate when nested is not object", () => {
     expect.assertions(4);
 
     class MySubClass {
@@ -109,23 +109,18 @@ describe('promise validation', () => {
     }
 
     class MyClass {
-      @ValidatePromise()
-      @ValidateNested()
+      @ValidatePromise() @ValidateNested()
       mySubClass: MySubClass;
     }
 
     const model = new MyClass();
-    model.mySubClass = 'invalidnested object' as any;
+    model.mySubClass = "invalidnested object" as any;
 
     return validator.validate(model).then(errors => {
       expect(errors[0].target).toEqual(model);
-      expect(errors[0].property).toEqual('mySubClass');
-      expect(errors[0].children.length).toEqual(1);
-
-      const subError = errors[0].children[0];
-      expect(subError.constraints).toEqual({
-        [ValidationTypes.NESTED_VALIDATION]: 'nested property mySubClass must be either object or array',
-      });
+      expect(errors[0].property).toEqual("mySubClass");
+      expect(errors[0].children.length).toEqual(0);
+      expect(errors[0].constraints).toEqual({[ValidationTypes.NESTED_VALIDATION]: "nested property mySubClass must be either object or array"});
     });
   });
 

--- a/test/functional/promise-validation.spec.ts
+++ b/test/functional/promise-validation.spec.ts
@@ -100,7 +100,7 @@ describe('promise validation', () => {
     });
   });
 
-  it("should validate when nested is not object", () => {
+  it('should validate when nested is not object', () => {
     expect.assertions(4);
 
     class MySubClass {
@@ -109,18 +109,21 @@ describe('promise validation', () => {
     }
 
     class MyClass {
-      @ValidatePromise() @ValidateNested()
+      @ValidatePromise()
+      @ValidateNested()
       mySubClass: MySubClass;
     }
 
     const model = new MyClass();
-    model.mySubClass = "invalidnested object" as any;
+    model.mySubClass = 'invalidnested object' as any;
 
     return validator.validate(model).then(errors => {
       expect(errors[0].target).toEqual(model);
-      expect(errors[0].property).toEqual("mySubClass");
+      expect(errors[0].property).toEqual('mySubClass');
       expect(errors[0].children.length).toEqual(0);
-      expect(errors[0].constraints).toEqual({[ValidationTypes.NESTED_VALIDATION]: "nested property mySubClass must be either object or array"});
+      expect(errors[0].constraints).toEqual({
+        [ValidationTypes.NESTED_VALIDATION]: 'nested property mySubClass must be either object or array',
+      });
     });
   });
 

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1221,12 +1221,23 @@ describe('context', () => {
     const model = new MyClass();
     model.nestedWithPrimitiveValue = "invalid" as any;
 
-    return validator.validate(model, { stopAtFirstError: true }).then(errors => {
+    const hasStopAtFirstError = validator.validate(model, { stopAtFirstError: true }).then(errors => {
       expect(errors.length).toEqual(2);
       expect(Object.keys(errors[0].constraints).length).toBe(1);
       expect(errors[0].constraints['isDefined']).toBe('isDefined');
       expect(Object.keys(errors[1].constraints).length).toBe(1);
       expect(errors[1].constraints).toHaveProperty('isArray');
     });
+    const hasNotStopAtFirstError = validator.validate(model, { stopAtFirstError: false }).then(errors => {
+      expect(errors.length).toEqual(2);
+      expect(Object.keys(errors[0].constraints).length).toBe(2);
+      expect(errors[0].constraints).toHaveProperty('contains');
+      expect(errors[0].constraints).toHaveProperty('isDefined');
+      expect(Object.keys(errors[1].constraints).length).toBe(2);
+      expect(errors[1].constraints).toHaveProperty('isArray');
+      expect(errors[1].constraints).toHaveProperty('nestedValidation');
+    })
+
+    return Promise.all([hasStopAtFirstError, hasNotStopAtFirstError]);
   });
 });

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1219,7 +1219,7 @@ describe('context', () => {
     }
 
     const model = new MyClass();
-    model.nestedWithPrimitiveValue = "invalid" as any;
+    model.nestedWithPrimitiveValue = 'invalid' as any;
 
     const hasStopAtFirstError = validator.validate(model, { stopAtFirstError: true }).then(errors => {
       expect(errors.length).toEqual(2);
@@ -1236,7 +1236,7 @@ describe('context', () => {
       expect(Object.keys(errors[1].constraints).length).toBe(2);
       expect(errors[1].constraints).toHaveProperty('isArray');
       expect(errors[1].constraints).toHaveProperty('nestedValidation');
-    })
+    });
 
     return Promise.all([hasStopAtFirstError, hasNotStopAtFirstError]);
   });

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -3,6 +3,7 @@ import {
   IsDefined,
   Matches,
   MinLength,
+  IsArray,
   Validate,
   ValidateNested,
   ValidatorConstraint,
@@ -1196,6 +1197,13 @@ describe('context', () => {
   });
 
   it('should stop at first error.', () => {
+    class MySubClass {
+      @IsDefined({
+        message: 'isDefined',
+      })
+      name: string;
+    }
+
     class MyClass {
       @IsDefined({
         message: 'isDefined',
@@ -1204,14 +1212,21 @@ describe('context', () => {
         message: 'String is not valid. You string must contain a hello word',
       })
       sameProperty: string;
+
+      @ValidateNested()
+      @IsArray()
+      nestedWithPrimitiveValue: MySubClass[];
     }
 
     const model = new MyClass();
+    model.nestedWithPrimitiveValue = "invalid" as any;
+
     return validator.validate(model, { stopAtFirstError: true }).then(errors => {
-      console.log();
-      expect(errors.length).toEqual(1);
+      expect(errors.length).toEqual(2);
       expect(Object.keys(errors[0].constraints).length).toBe(1);
       expect(errors[0].constraints['isDefined']).toBe('isDefined');
+      expect(Object.keys(errors[1].constraints).length).toBe(1);
+      expect(errors[1].constraints).toHaveProperty('isArray');
     });
   });
 });


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

Fixes an error when property with `@NestedValidation` decorator holds primitive value. The error messages is applied to the wrong place on the child. This PR fixes it and places the error correctly on the parent object instead of the child. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->

fixes #679


