### PR TITLE
build: setup project for TypeScript solution file

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,9 +4,10 @@ plugins:
 parserOptions:
   ecmaVersion: 2018
   sourceType: module
-  project: 
-    - ./tsconfig.json
+  project:
+    - ./tsconfig.prod.json
     - ./tsconfig.spec.json
+    - ./tsconfig.sample.json
 extends:
   - 'plugin:@typescript-eslint/recommended'
   - 'plugin:@typescript-eslint/recommended-requiring-type-checking'
@@ -25,8 +26,8 @@ rules:
   '@typescript-eslint/no-unused-vars':
     - 'error'
     - args: 'none'
-  # TODO: Remove these and fixed issues once we merged all the current PRs. 
-  '@typescript-eslint/ban-types': off 
+  # TODO: Remove these and fixed issues once we merged all the current PRs.
+  '@typescript-eslint/ban-types': off
   '@typescript-eslint/no-unsafe-return': off
   '@typescript-eslint/no-unsafe-assignment': off
   '@typescript-eslint/no-unsafe-call': off

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2018",
+    "lib": ["es2018"],
+    "outDir": "./build/node",
+    "rootDir": "./",
+    "strict": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,14 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "es2018",
-    "lib": ["es2018"],
-    "outDir": "build/node",
-    "rootDir": "./src",
-    "strict": true,
-    "sourceMap": true,
-    "removeComments": false,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "exclude": ["build", "node_modules", "sample", "**/*.spec.ts", "test/**"]
+    "files": [],
+    "references": [
+        {
+            "path": "./tsconfig.prod.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        },
+        {
+            "path": "./tsconfig.sample.json"
+        }
+    ]
 }

--- a/tsconfig.prod.cjs.json
+++ b/tsconfig.prod.cjs.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.prod.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "outDir": "build/cjs"
-  },
+    "outDir": "./build/cjs"
+  }
 }

--- a/tsconfig.prod.esm2015.json
+++ b/tsconfig.prod.esm2015.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.prod.json",
   "compilerOptions": {
     "module": "ES2015",
-    "outDir": "build/esm2015",
-  },
+    "outDir": "./build/esm2015"
+  }
 }

--- a/tsconfig.prod.esm5.json
+++ b/tsconfig.prod.esm5.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "module": "ES2015",
     "target": "ES5",
-    "outDir": "build/esm5",
-  },
+    "outDir": "./build/esm5"
+  }
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,7 +1,11 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "strict": false,
     "declaration": false,
+    "rootDir": "./src"
   },
+  "files": [
+    "./src/index.ts"
+  ]
 }

--- a/tsconfig.prod.types.json
+++ b/tsconfig.prod.types.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "build/types",
-  },
+    "outDir": "./build/types"
+  }
 }

--- a/tsconfig.sample.json
+++ b/tsconfig.sample.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "strict": false
+  },
+  "include": [
+    "./sample/**/*.ts"
+  ]
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,11 +1,13 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "strict": false,
     "strictPropertyInitialization": false,
     "sourceMap": false,
     "removeComments": true,
-    "noImplicitAny": false,
+    "noImplicitAny": false
   },
-  "exclude": ["node_modules"]
+  "include": [
+    "./test/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Configures prod, spec and sample projects and references them in solution file.
This improves integration with tooling such as IDEs.
See [TS docs](https://www.typescriptlang.org/docs/handbook/project-references.html#overall-structure) for guidance on how to use project references to structure TS projects.
