### PR TITLE
fix: return errors separated <comma><space> instead of <comma> in IsIn decorator

### DIFF
--- a/src/validation/ValidationUtils.ts
+++ b/src/validation/ValidationUtils.ts
@@ -27,7 +27,10 @@ export class ValidationUtils {
 
     if (messageString && validationArguments.constraints instanceof Array) {
       validationArguments.constraints.forEach((constraint, index) => {
-        messageString = messageString.replace(new RegExp(`\\$constraint${index + 1}`, 'g'), constraintToString(constraint));
+        messageString = messageString.replace(
+          new RegExp(`\\$constraint${index + 1}`, 'g'),
+          constraintToString(constraint)
+        );
       });
     }
 

--- a/src/validation/ValidationUtils.ts
+++ b/src/validation/ValidationUtils.ts
@@ -1,5 +1,18 @@
 import { ValidationArguments } from './ValidationArguments';
 
+/**
+ * Convert the constraint to a string to be shown in an error
+ */
+export function constraintToString(constraint: unknown): string {
+  if (typeof constraint === 'string') return constraint;
+
+  // join array as <comma><space> separated values strings
+  if (Array.isArray(constraint)) return constraint.map(constraintToString).join(', ');
+
+  // convert to string...
+  return String(constraint);
+}
+
 export class ValidationUtils {
   static replaceMessageSpecialTokens(
     message: string | ((args: ValidationArguments) => string),
@@ -14,7 +27,7 @@ export class ValidationUtils {
 
     if (messageString && validationArguments.constraints instanceof Array) {
       validationArguments.constraints.forEach((constraint, index) => {
-        messageString = messageString.replace(new RegExp(`\\$constraint${index + 1}`, 'g'), constraint);
+        messageString = messageString.replace(new RegExp(`\\$constraint${index + 1}`, 'g'), constraintToString(constraint));
       });
     }
 

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -187,6 +187,7 @@ import {
 } from '../../src/decorator/decorators';
 import { Validator } from '../../src/validation/Validator';
 import { ValidatorOptions } from '../../src/validation/ValidatorOptions';
+import { constraintToString } from '../../src/validation/ValidationUtils';
 import { default as ValidatorJS } from 'validator';
 
 export function checkValidValues(
@@ -341,7 +342,7 @@ describe('Equals', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'equals';
-    const message = 'someProperty must be equal to ' + constraint;
+    const message = 'someProperty must be equal to ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -374,7 +375,7 @@ describe('NotEquals', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'notEquals';
-    const message = 'someProperty should not be equal to ' + constraint;
+    const message = 'someProperty should not be equal to ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -450,7 +451,7 @@ describe('IsIn', () => {
 
   class MyClass {
     @IsIn(constraint)
-    someProperty: string;
+    someProperty: string[];
   }
 
   it('should not fail if validator.validate said that its valid', () => {
@@ -471,7 +472,7 @@ describe('IsIn', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isIn';
-    const message = 'someProperty must be one of the following values: ' + constraint;
+    const message = 'someProperty must be one of the following values: ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -504,7 +505,7 @@ describe('IsNotIn', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isNotIn';
-    const message = 'someProperty should not be one of the following values: ' + constraint;
+    const message = 'someProperty should not be one of the following values: ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -970,7 +971,7 @@ describe('IsDivisibleBy', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isDivisibleBy';
-    const message = 'someProperty must be divisible by ' + constraint;
+    const message = 'someProperty must be divisible by ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -1105,7 +1106,7 @@ describe('Min', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'min';
-    const message = 'someProperty must not be less than ' + constraint;
+    const message = 'someProperty must not be less than ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -1138,7 +1139,7 @@ describe('Max', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'max';
-    const message = 'someProperty must not be greater than ' + constraint;
+    const message = 'someProperty must not be greater than ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -1171,7 +1172,7 @@ describe('MinDate', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'minDate';
-    const message = 'minimal allowed date for someProperty is ' + constraint;
+    const message = 'minimal allowed date for someProperty is ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -1204,7 +1205,7 @@ describe('MaxDate', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'maxDate';
-    const message = 'maximal allowed date for someProperty is ' + constraint;
+    const message = 'maximal allowed date for someProperty is ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -1301,7 +1302,7 @@ describe('Contains', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'contains';
-    const message = 'someProperty must contain a ' + constraint + ' string';
+    const message = 'someProperty must contain a ' + constraintToString(constraint) + ' string';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -1334,7 +1335,7 @@ describe('NotContains', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'notContains';
-    const message = 'someProperty should not contain a ' + constraint + ' string';
+    const message = 'someProperty should not contain a ' + constraintToString(constraint) + ' string';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -2220,7 +2221,7 @@ describe('IsByteLength', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isByteLength';
-    const message = "someProperty's byte length must fall into (" + constraint1 + ', ' + constraint2 + ') range';
+    const message = "someProperty's byte length must fall into (" + constraintToString(constraint1) + ', ' + constraintToString(constraint2) + ') range';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3657,13 +3658,13 @@ describe('Length', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'length';
-    const message = 'someProperty must be longer than or equal to ' + constraint1 + ' characters';
+    const message = 'someProperty must be longer than or equal to ' + constraintToString(constraint1) + ' characters';
     checkReturnedError(new MyClass(), ['', 'a'], validationType, message);
   });
 
   it('should return error object with proper data', () => {
     const validationType = 'length';
-    const message = 'someProperty must be shorter than or equal to ' + constraint2 + ' characters';
+    const message = 'someProperty must be shorter than or equal to ' + constraintToString(constraint2) + ' characters';
     checkReturnedError(new MyClass(), ['aaaa', 'azzazza'], validationType, message);
   });
 });
@@ -3696,7 +3697,7 @@ describe('MinLength', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'minLength';
-    const message = 'someProperty must be longer than or equal to ' + constraint1 + ' characters';
+    const message = 'someProperty must be longer than or equal to ' + constraintToString(constraint1) + ' characters';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3729,7 +3730,7 @@ describe('MaxLength', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'maxLength';
-    const message = 'someProperty must be shorter than or equal to ' + constraint1 + ' characters';
+    const message = 'someProperty must be shorter than or equal to ' + constraintToString(constraint1) + ' characters';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3762,7 +3763,7 @@ describe('Matches pattern RegExp', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'matches';
-    const message = 'someProperty must match ' + constraint + ' regular expression';
+    const message = 'someProperty must match ' + constraintToString(constraint) + ' regular expression';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3796,7 +3797,7 @@ describe('Matches pattern string with modifier', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'matches';
-    const message = 'someProperty must match ' + constraint + ' regular expression';
+    const message = 'someProperty must match ' + constraintToString(constraint) + ' regular expression';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -4203,7 +4204,7 @@ describe('ArrayContains', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'arrayContains';
-    const message = 'someProperty must contain ' + constraint + ' values';
+    const message = 'someProperty must contain ' + constraintToString(constraint) + ' values';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -4242,7 +4243,7 @@ describe('ArrayNotContains', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'arrayNotContains';
-    const message = 'someProperty should not contain ' + constraint + ' values';
+    const message = 'someProperty should not contain ' + constraintToString(constraint) + ' values';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -4316,7 +4317,7 @@ describe('ArrayMinSize', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'arrayMinSize';
-    const message = 'someProperty must contain at least ' + constraint + ' elements';
+    const message = 'someProperty must contain at least ' + constraintToString(constraint) + ' elements';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -4349,7 +4350,7 @@ describe('ArrayMaxSize', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'arrayMaxSize';
-    const message = 'someProperty must contain not more than ' + constraint + ' elements';
+    const message = 'someProperty must contain not more than ' + constraintToString(constraint) + ' elements';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -2221,7 +2221,12 @@ describe('IsByteLength', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isByteLength';
-    const message = "someProperty's byte length must fall into (" + constraintToString(constraint1) + ', ' + constraintToString(constraint2) + ') range';
+    const message =
+      "someProperty's byte length must fall into (" +
+      constraintToString(constraint1) +
+      ', ' +
+      constraintToString(constraint2) +
+      ') range';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });


### PR DESCRIPTION
## Description
Format the `IsIn` validators error message constraints to be separated by "\<comma\>\<space\>", instead of "\<comma\>".

For example:

`"userType must be one of the following values: admin,user"`
becomes
`"userType must be one of the following values: admin, user"`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #625 
