### PR TITLE
fix: correct typo in IsUUID decorator

### DIFF
--- a/src/decorator/string/IsUUID.ts
+++ b/src/decorator/string/IsUUID.ts
@@ -25,7 +25,7 @@ export function IsUUID(version?: UUIDVersion, validationOptions?: ValidationOpti
       constraints: [version],
       validator: {
         validate: (value, args): boolean => isUUID(value, args.constraints[0]),
-        defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be an UUID', validationOptions),
+        defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a UUID', validationOptions),
       },
     },
     validationOptions

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -3410,7 +3410,7 @@ describe('IsUUID', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isUuid';
-    const message = 'someProperty must be an UUID';
+    const message = 'someProperty must be a UUID';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3451,7 +3451,7 @@ describe('IsUUID v3', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isUuid';
-    const message = 'someProperty must be an UUID';
+    const message = 'someProperty must be a UUID';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3497,7 +3497,7 @@ describe('IsUUID v4', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isUuid';
-    const message = 'someProperty must be an UUID';
+    const message = 'someProperty must be a UUID';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
@@ -3543,7 +3543,7 @@ describe('IsUUID v5', () => {
 
   it('should return error object with proper data', () => {
     const validationType = 'isUuid';
-    const message = 'someProperty must be an UUID';
+    const message = 'someProperty must be a UUID';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });


### PR DESCRIPTION
## Description
Fix typo in IsUUID.js error message, it should be `a UUID` instead of `an UUID`, since UUID is pronounced with a hard Y. Just like UFO.
