### PR TITLE
fix: do not throw in ValidationError.toString() error when using forbidNonWhitelisted option

### DIFF
--- a/src/validation/ValidationError.ts
+++ b/src/validation/ValidationError.ts
@@ -31,7 +31,7 @@ export class ValidationError {
   /**
    * Contains all nested validation errors of the property.
    */
-  children: ValidationError[];
+  children?: ValidationError[];
 
   /*
    * A transient set of data passed through to the validation result for response mapping
@@ -60,7 +60,9 @@ export class ValidationError {
           this.target ? this.target.constructor.name : 'an object'
         }${boldEnd} has failed the validation:\n` +
         (this.constraints ? propConstraintFailed(this.property) : ``) +
-        this.children.map(childError => childError.toString(shouldDecorate, true, this.property)).join(``)
+        (this.children
+          ? this.children.map(childError => childError.toString(shouldDecorate, true, this.property)).join(``)
+          : ``)
       );
     } else {
       // we format numbers as array indexes for better readability.
@@ -72,8 +74,10 @@ export class ValidationError {
         return propConstraintFailed(formattedProperty);
       } else {
         return this.children
-          .map(childError => childError.toString(shouldDecorate, true, `${parentPath}${formattedProperty}`))
-          .join(``);
+          ? this.children
+              .map(childError => childError.toString(shouldDecorate, true, `${parentPath}${formattedProperty}`))
+              .join(``)
+          : ``;
       }
     }
   }

--- a/test/functional/whitelist-validation.spec.ts
+++ b/test/functional/whitelist-validation.spec.ts
@@ -57,6 +57,7 @@ describe('whitelist validation', () => {
       expect(errors[0].target).toEqual(model);
       expect(errors[0].property).toEqual('unallowedProperty');
       expect(errors[0].constraints).toHaveProperty(ValidationTypes.WHITELIST);
+      expect(() => errors[0].toString()).not.toThrowError();
     });
   });
 });


### PR DESCRIPTION
## Description

When validation is performed with the `forbidNonWhitelisted` option, for any non-whitelisted properties, a `ValidationError` is created with the `children` property `undefined`. This breaks the current implementation of `ValidationError.toString()` which will try to map the `children` property, causing an error to be thrown. See #604.

This PR resolves the issue by testing `children` before mapping. Keeping the property optional feels semantically preferable to an empty list. The whitelist validation test is updated to cover this scenario.

## Checklist

- [X] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [X] the pull request targets the *default* branch of the repository (`develop`)
- [X] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [X] tests are added for the changes I made (if any source code was modified)
- [N/A] documentation added or updated
- [X] I have run the project locally and verified that there are no errors

### Fixes

fixes #604
