### PR TITLE
fix: Incorrect @types/validator dependency in latest version (0.13.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,8 +1033,7 @@
     "@types/validator": {
       "version": "13.1.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==",
-      "dev": true
+      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
     },
     "@types/yargs": {
       "version": "15.0.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:ci": "jest --runInBand --no-cache --coverage --verbose"
   },
   "dependencies": {
+    "@types/validator": "^13.1.3",
     "libphonenumber-js": "^1.9.7",
     "validator": "^13.5.2"
   },
@@ -44,7 +45,6 @@
     "@rollup/plugin-node-resolve": "^11.0.1",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.20",
-    "@types/validator": "^13.1.3",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
     "eslint": "^7.17.0",

--- a/src/validation/ValidationUtils.ts
+++ b/src/validation/ValidationUtils.ts
@@ -8,7 +8,7 @@ export function constraintToString(constraint: unknown): string {
     return constraint.join(', ');
   }
 
-  return `${ constraint }`;
+  return `${constraint}`;
 }
 
 export class ValidationUtils {


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

In 749fb26281a73ef43ce7e297f8b92be8a419c8cb, `@types/validator` was moved from `dependencies` to `devDependencies`. 

This causes those without `skipLibCheck` to set to `true` to get build errors, as `validator` is used in many of the generated type definitions.

This PR moves `@types/validator` back into `dependencies`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #869
