### PR TITLE
feat: Pass extra validation arguments to message builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ export interface ValidatorOptions {
 
   forbidUnknownValues?: boolean;
   stopAtFirstError?: boolean;
+  extraArguments?: ExtraValidationArguments;
 }
 ```
 
@@ -258,6 +259,23 @@ Message function accepts `ValidationArguments` which contains the following info
 - `targetName` - name of the object's class being validated
 - `object` - object that is being validated
 - `property` - name of the object's property being validated
+- any other arguments passed by the caller via `ValidatorOptions.extraArguments`. 
+Exact types of extra arguments can be specified with type merging:
+
+  ```typescript
+  declare module 'class-validator' {
+    interface ExtraArguments {
+      t: TFunction;
+    }
+  }
+
+  export class Post {
+    @MinLength(10, {
+      message: ({t}) => t('translation_key'),
+    })
+    title: string; 
+  }
+  ```
 
 ## Validating arrays
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Exact types of extra arguments can be specified with type merging:
 
   ```typescript
   declare module 'class-validator' {
-    interface ExtraArguments {
+    interface ExtraValidationArguments {
       t: TFunction;
     }
   }

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ Message function accepts `ValidationArguments` which contains the following info
 - `targetName` - name of the object's class being validated
 - `object` - object that is being validated
 - `property` - name of the object's property being validated
-- any other arguments passed by the caller via `ValidatorOptions.extraArguments`. 
-Exact types of extra arguments can be specified with type merging:
+- any other arguments passed by the caller via `ValidatorOptions.extraArguments`.
+  Exact types of extra arguments can be specified with type merging:
 
   ```typescript
   declare module 'class-validator' {
@@ -271,9 +271,9 @@ Exact types of extra arguments can be specified with type merging:
 
   export class Post {
     @MinLength(10, {
-      message: ({t}) => t('translation_key'),
+      message: ({ t }) => t('translation_key'),
     })
-    title: string; 
+    title: string;
   }
   ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export * from './validation/ValidatorConstraintInterface';
 export * from './validation/ValidationError';
 export * from './validation/ValidatorOptions';
 export * from './validation/ValidationArguments';
+export * from './validation/ExtraValidationArguments';
 export * from './validation/ValidationTypes';
 export * from './validation/Validator';
 export * from './validation-schema/ValidationSchema';

--- a/src/validation/ExtraValidationArguments.ts
+++ b/src/validation/ExtraValidationArguments.ts
@@ -1,7 +1,7 @@
 /**
  * Extra validation arguments that can be passed from caller of validate() to message builders.
  *
- * This type can be augumented using type merging to pass arguments in typesafe way, e.g.
+ * This type can be augmented using type merging to pass arguments in typesafe way, e.g.
  * ```typescript
  * declare module 'class-validator' {
  *   interface ExtraValidationArguments {
@@ -12,5 +12,5 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ExtraValidationArguments {
-  // for augumentation with type merging
+  // for augmentation with type merging
 }

--- a/src/validation/ExtraValidationArguments.ts
+++ b/src/validation/ExtraValidationArguments.ts
@@ -5,7 +5,7 @@
  * This type can be augumented using type merging to pass arguments in typesafe way, e.g.
  * ```typescript
  * declare module 'class-validator' {
- *   interface ExtraArguments {
+ *   interface ExtraValidationArguments {
  *     t: TFunction;
  *   }
  * }

--- a/src/validation/ExtraValidationArguments.ts
+++ b/src/validation/ExtraValidationArguments.ts
@@ -1,7 +1,6 @@
-
 /**
  * Extra validation arguments that can be passed from caller of validate() to message builders.
- * 
+ *
  * This type can be augumented using type merging to pass arguments in typesafe way, e.g.
  * ```typescript
  * declare module 'class-validator' {

--- a/src/validation/ExtraValidationArguments.ts
+++ b/src/validation/ExtraValidationArguments.ts
@@ -1,0 +1,17 @@
+
+/**
+ * Extra validation arguments that can be passed from caller of validate() to message builders.
+ * 
+ * This type can be augumented using type merging to pass arguments in typesafe way, e.g.
+ * ```typescript
+ * declare module 'class-validator' {
+ *   interface ExtraArguments {
+ *     t: TFunction;
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ExtraValidationArguments {
+  // for augumentation with type merging
+}

--- a/src/validation/ValidationArguments.ts
+++ b/src/validation/ValidationArguments.ts
@@ -1,4 +1,4 @@
-import { ExtraValidationArguments } from "./ExtraValidationArguments";
+import { ExtraValidationArguments } from './ExtraValidationArguments';
 
 /**
  * Arguments being sent to message builders - user can create message either by simply returning a string,

--- a/src/validation/ValidationArguments.ts
+++ b/src/validation/ValidationArguments.ts
@@ -1,8 +1,10 @@
+import { ExtraValidationArguments } from "./ExtraValidationArguments";
+
 /**
  * Arguments being sent to message builders - user can create message either by simply returning a string,
  * either by returning a function that accepts MessageArguments and returns a message string built based on these arguments.
  */
-export interface ValidationArguments {
+export interface ValidationArguments extends ExtraValidationArguments {
   /**
    * Validating value.
    */

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -260,6 +260,7 @@ export class ValidationExecutor {
           object: object,
           value: value,
           constraints: metadata.constraints,
+          ...this.validatorOptions?.extraArguments,
         };
 
         if (!metadata.each || !(value instanceof Array || value instanceof Set || value instanceof Map)) {
@@ -402,6 +403,7 @@ export class ValidationExecutor {
       object: object,
       value: value,
       constraints: metadata.constraints,
+      ...this.validatorOptions?.extraArguments,
     };
 
     let message = metadata.message || '';

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -1,3 +1,5 @@
+import { ExtraValidationArguments } from "./ExtraValidationArguments";
+
 /**
  * Options passed to validator during validation.
  */
@@ -80,4 +82,9 @@ export interface ValidatorOptions {
    * When set to true, validation of the given property will stop after encountering the first error. Defaults to false.
    */
   stopAtFirstError?: boolean;
+
+  /**
+   * Extra arguments to be passed to message builders.
+   */
+  extraArguments?: ExtraValidationArguments;
 }

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -1,4 +1,4 @@
-import { ExtraValidationArguments } from "./ExtraValidationArguments";
+import { ExtraValidationArguments } from './ExtraValidationArguments';
 
 /**
  * Options passed to validator during validation.

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -1,7 +1,13 @@
-import { IsNotEmpty } from '../../src/decorator/decorators';
+import { IsNotEmpty, ValidateBy } from '../../src/decorator/decorators';
 import { Validator } from '../../src/validation/Validator';
 
 const validator = new Validator();
+
+declare module '../../src/validation/ExtraValidationArguments' {
+  interface ExtraValidationArguments {
+    t: (msg: string) => string
+  }
+}
 
 describe('validator options', () => {
   it('should not return target in validation error if validationError: { target: false } is set', () => {
@@ -43,5 +49,45 @@ describe('validator options', () => {
     return validator.validate(anonymousObject, { forbidUnknownValues: false }).then(errors => {
       expect(errors.length).toEqual(0);
     });
+  });
+
+  it('should pass extra validation arguments to message builder', function () {
+    class MyClass {
+      @IsNotEmpty({ message: ({t}) => t('this field should not be empty')})
+      title: string = '';
+      isActive: boolean;
+    }
+
+    const model = new MyClass();
+    model.title = '';
+    return validator
+      .validate(model, { extraArguments: { t: (msg) => 'translated: ' + msg } })
+      .then(errors => {
+        expect(errors.length).toEqual(1);
+        expect(errors[0].constraints).toEqual({ isNotEmpty: 'translated: this field should not be empty' });
+      });
+  });
+
+  it('should pass extra validation arguments to default message builder', function () {
+    class MyClass {
+      @ValidateBy({
+        name: 'customValidator',
+        validator: {
+          validate: () => false,
+          defaultMessage: ({t}) => t('custom error')
+        }
+      })
+      title: string = '';
+      isActive: boolean;
+    }
+
+    const model = new MyClass();
+    model.title = '';
+    return validator
+      .validate(model, { extraArguments: { t: (msg) => 'translated: ' + msg } })
+      .then(errors => {
+        expect(errors.length).toEqual(1);
+        expect(errors[0].constraints).toEqual({ customValidator: 'translated: custom error' });
+      });
   });
 });

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -5,7 +5,7 @@ const validator = new Validator();
 
 declare module '../../src/validation/ExtraValidationArguments' {
   interface ExtraValidationArguments {
-    t: (msg: string) => string
+    t: (msg: string) => string;
   }
 }
 
@@ -53,19 +53,17 @@ describe('validator options', () => {
 
   it('should pass extra validation arguments to message builder', function () {
     class MyClass {
-      @IsNotEmpty({ message: ({t}) => t('this field should not be empty')})
+      @IsNotEmpty({ message: ({ t }) => t('this field should not be empty') })
       title: string = '';
       isActive: boolean;
     }
 
     const model = new MyClass();
     model.title = '';
-    return validator
-      .validate(model, { extraArguments: { t: (msg) => 'translated: ' + msg } })
-      .then(errors => {
-        expect(errors.length).toEqual(1);
-        expect(errors[0].constraints).toEqual({ isNotEmpty: 'translated: this field should not be empty' });
-      });
+    return validator.validate(model, { extraArguments: { t: msg => 'translated: ' + msg } }).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].constraints).toEqual({ isNotEmpty: 'translated: this field should not be empty' });
+    });
   });
 
   it('should pass extra validation arguments to default message builder', function () {
@@ -74,8 +72,8 @@ describe('validator options', () => {
         name: 'customValidator',
         validator: {
           validate: () => false,
-          defaultMessage: ({t}) => t('custom error')
-        }
+          defaultMessage: ({ t }) => t('custom error'),
+        },
       })
       title: string = '';
       isActive: boolean;
@@ -83,11 +81,9 @@ describe('validator options', () => {
 
     const model = new MyClass();
     model.title = '';
-    return validator
-      .validate(model, { extraArguments: { t: (msg) => 'translated: ' + msg } })
-      .then(errors => {
-        expect(errors.length).toEqual(1);
-        expect(errors[0].constraints).toEqual({ customValidator: 'translated: custom error' });
-      });
+    return validator.validate(model, { extraArguments: { t: msg => 'translated: ' + msg } }).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].constraints).toEqual({ customValidator: 'translated: custom error' });
+    });
   });
 });


### PR DESCRIPTION
## Description
Allow caller of ``validate()`` to pass extra arguments to message builders.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #961
