### PR TITLE
feat: add `IsReadOnly` decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ isBoolean(value);
 | `@NotEquals(comparison: any)`                   | Checks if value not equal ("!==") comparison. |
 | `@IsEmpty()`                                    | Checks if given value is empty (=== '', === null, === undefined). |
 | `@IsNotEmpty()`                                 | Checks if given value is not empty (!== '', !== null, !== undefined). |
+| `@IsReadOnly()`                                 | Checks if given value is undefined to prevent change value. |
 | `@IsIn(values: any[])`                          | Checks if value is in a array of allowed values. |
 | `@IsNotIn(values: any[])`                       | Checks if value is not in a array of disallowed values. |
 | **Type validation decorators**                  | |

--- a/src/decorator/common/IsReadOnly.ts
+++ b/src/decorator/common/IsReadOnly.ts
@@ -1,0 +1,27 @@
+import { ValidationOptions } from '../ValidationOptions';
+import { buildMessage, ValidateBy } from './ValidateBy';
+
+export const IS_READONLY = 'isReadOnly';
+
+/**
+ * Checks if given value is undefined.
+ */
+export function isReadOnly(value: unknown): boolean {
+  return value === undefined;
+}
+
+/**
+ * Checks if given value is undefined.
+ */
+export function IsReadOnly(validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: IS_READONLY,
+      validator: {
+        validate: (value, args): boolean => isReadOnly(value),
+        defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be undefined', validationOptions),
+      },
+    },
+    validationOptions
+  );
+}

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -23,6 +23,7 @@ export * from './common/IsEmpty';
 export * from './common/IsNotEmpty';
 export * from './common/IsIn';
 export * from './common/IsNotIn';
+export * from './common/IsReadOnly';
 
 // -------------------------------------------------------------------------
 // Number checkers

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -184,6 +184,8 @@ import {
   isPostalCode,
   IsSemVer,
   isSemVer,
+  IsReadOnly,
+  isReadOnly,
 } from '../../src/decorator/decorators';
 import { Validator } from '../../src/validation/Validator';
 import { ValidatorOptions } from '../../src/validation/ValidatorOptions';
@@ -443,6 +445,39 @@ describe('IsNotEmpty', () => {
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });
+
+describe('IsReadOnly', () => {
+  const validValues = [undefined];
+  const invalidValues = ['0', 0, 1, false, true, null, ''];
+
+  class MyClass {
+    @IsReadOnly()
+    someProperty: string;
+  }
+
+  it('should not fail if validator.validate said that its valid', () => {
+    return checkValidValues(new MyClass(), validValues);
+  });
+
+  it('should fail if validator.validate said that its invalid', () => {
+    return checkInvalidValues(new MyClass(), invalidValues);
+  });
+
+  it('should not fail if method in validator said that its valid', () => {
+    validValues.forEach(value => expect(isReadOnly(value)).toBeTruthy());
+  });
+
+  it('should fail if method in validator said that its invalid', () => {
+    invalidValues.forEach(value => expect(isReadOnly(value)).toBeFalsy());
+  });
+
+  it('should return error object with proper data', () => {
+    const validationType = 'isReadOnly';
+    const message = 'someProperty must be undefined';
+    return checkReturnedError(new MyClass(), invalidValues, validationType, message);
+  });
+});
+
 
 describe('IsIn', () => {
   const constraint = ['foo', 'bar'] as const;


### PR DESCRIPTION
## Description
Add `IsReadOnly` decorator to prevent set some values to specific property: input value for property must be `undefined`.

This decorator in futher may be used with JSON-schema generators (such as `class-validator-jsonschema`) to make `readOnly: true` value.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1274
