### PR TITLE
fix: #438 default forbidUnknownValues to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ export interface ValidatorOptions {
 }
 ```
 
-> It's highly advised to set `forbidUnknownValues: true` as it will prevent unknown objects from passing validation.
+> It's highly advised to not set `forbidUnknownValues: false` as it will allow unknown objects to bypass validation. The default is a safe value of `true`.
 
 ## Validation errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,7 +1154,8 @@
     "@types/validator": {
       "version": "13.6.6",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.6.tgz",
-      "integrity": "sha512-+qogUELb4gMhrMjSh/seKmGVvN+uQLfyqJAqYRWqVHsvBsUO2xDBCL8CJ/ZSukbd8vXaoYbpIssAmfLEzzBHEw=="
+      "integrity": "sha512-+qogUELb4gMhrMjSh/seKmGVvN+uQLfyqJAqYRWqVHsvBsUO2xDBCL8CJ/ZSukbd8vXaoYbpIssAmfLEzzBHEw==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "15.0.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "test:ci": "jest --runInBand --no-cache --coverage --verbose"
   },
   "dependencies": {
-    "@types/validator": "^13.6.6",
     "libphonenumber-js": "^1.9.42",
     "validator": "^13.7.0"
   },
@@ -45,6 +44,7 @@
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.7",
+    "@types/validator": "^13.6.6",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -52,6 +52,7 @@ export class ValidationExecutor {
     const groups = this.validatorOptions ? this.validatorOptions.groups : undefined;
     const strictGroups = (this.validatorOptions && this.validatorOptions.strictGroups) || false;
     const always = (this.validatorOptions && this.validatorOptions.always) || false;
+    const forbidUnknownValues = (this.validatorOptions?.forbidUnknownValues ?? true);
 
     const targetMetadatas = this.metadataStorage.getTargetValidationMetadatas(
       object.constructor,
@@ -62,7 +63,7 @@ export class ValidationExecutor {
     );
     const groupedMetadatas = this.metadataStorage.groupByPropertyName(targetMetadatas);
 
-    if (this.validatorOptions && this.validatorOptions.forbidUnknownValues && !targetMetadatas.length) {
+    if (forbidUnknownValues && !targetMetadatas.length) {
       const validationError = new ValidationError();
 
       if (

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -52,7 +52,7 @@ export class ValidationExecutor {
     const groups = this.validatorOptions ? this.validatorOptions.groups : undefined;
     const strictGroups = (this.validatorOptions && this.validatorOptions.strictGroups) || false;
     const always = (this.validatorOptions && this.validatorOptions.always) || false;
-    const forbidUnknownValues = (this.validatorOptions?.forbidUnknownValues ?? true);
+    const forbidUnknownValues = this.validatorOptions?.forbidUnknownValues ?? true;
 
     const targetMetadatas = this.metadataStorage.getTargetValidationMetadatas(
       object.constructor,

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -45,7 +45,7 @@ export class ValidationExecutor {
      */
     if (!this.metadataStorage.hasValidationMetaData && this.validatorOptions?.enableDebugMessages === true) {
       console.warn(
-        `No metadata found. There is more than once class-validator version installed probably. You need to flatten your dependencies.`
+        `No metadata found. There is more than one class-validator version installed probably. You need to flatten your dependencies.`
       );
     }
 

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -72,7 +72,8 @@ export interface ValidatorOptions {
   };
 
   /**
-   * Settings true will cause fail validation of unknown objects.
+   * Setting this to false will allow unknown objects (i.e. objects whose prototype classes have no validation metadata) to pass validation.
+   * If you do not specify a value or you use null or undefined, a safe value of true will be used to prevent accidental validation bypass.
    */
   forbidUnknownValues?: boolean;
 

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -74,14 +74,14 @@ export interface ValidatorOptions {
   /**
    * Setting this to false will allow unknown objects (i.e. objects whose prototype classes have no validation metadata) to pass validation.
    * If you do not specify a value or you use null or undefined, a safe value of true will be used to prevent accidental validation bypass.
-   * 
+   *
    * For instance, since a plain empty object has no annotations used for validation:
    * - `validate({}, { })` // fails
    * - `validate({}, { forbidUnknownValues: true })` // fails
    * - `validate({}, { forbidUnknownValues: false })` // passes
    * - `validate(new SomeAnnotatedEmptyClass(), { forbidUnknownValues: true })` // passes
    * - `validate(new SomeAnnotatedEmptyClass(), { })` // passes
-  */
+   */
   forbidUnknownValues?: boolean;
 
   /**

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -74,7 +74,14 @@ export interface ValidatorOptions {
   /**
    * Setting this to false will allow unknown objects (i.e. objects whose prototype classes have no validation metadata) to pass validation.
    * If you do not specify a value or you use null or undefined, a safe value of true will be used to prevent accidental validation bypass.
-   */
+   * 
+   * For instance, since a plain empty object has no annotations used for validation:
+   * - `validate({}, { })` // fails
+   * - `validate({}, { forbidUnknownValues: true })` // fails
+   * - `validate({}, { forbidUnknownValues: false })` // passes
+   * - `validate(new SomeAnnotatedEmptyClass(), { forbidUnknownValues: true })` // passes
+   * - `validate(new SomeAnnotatedEmptyClass(), { })` // passes
+  */
   forbidUnknownValues?: boolean;
 
   /**

--- a/test/functional/reject-validation.spec.ts
+++ b/test/functional/reject-validation.spec.ts
@@ -18,22 +18,25 @@ describe('validateOrReject()', () => {
     model = new MyClass();
   });
 
-  it('should resolve promise when no error', () => {
+  it('should resolve promise when no error', async () => {
     expect.assertions(1);
     model.someProperty = 'hello world';
-    return validator.validateOrReject(model).then(args => {
-      expect(args).toBeUndefined();
-    });
+    const args = await validator.validateOrReject(model);
+    expect(args).toBeUndefined();
   });
 
-  it('should reject promise on error', () => {
+  it('should reject promise on error', async () => {
     expect.assertions(2);
     model.someProperty = 'hell no world';
-    return validator.validateOrReject(model).catch((errors: ValidationError[]) => {
-      expect(errors.length).toEqual(1);
-      expect(errors[0].constraints).toEqual({
-        contains: 'hell no world is not valid. Your string must contain a hello word',
-      });
+    let errors: ValidationError[];
+    try {
+      await validator.validateOrReject(model);
+    } catch (caught) {
+      errors = caught;
+    }
+    expect(errors.length).toEqual(1);
+    expect(errors[0].constraints).toEqual({
+      contains: 'hell no world is not valid. Your string must contain a hello word',
     });
   });
 });

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -3662,15 +3662,15 @@ describe('Length', () => {
   });
 
   it('should return error object with proper data', () => {
-    const validationType = 'length';
+    const validationType = 'isLength';
     const message = 'someProperty must be longer than or equal to ' + constraintToString(constraint1) + ' characters';
-    checkReturnedError(new MyClass(), ['', 'a'], validationType, message);
+    return checkReturnedError(new MyClass(), ['', 'a'], validationType, message);
   });
 
   it('should return error object with proper data', () => {
-    const validationType = 'length';
+    const validationType = 'isLength';
     const message = 'someProperty must be shorter than or equal to ' + constraintToString(constraint2) + ' characters';
-    checkReturnedError(new MyClass(), ['aaaa', 'azzazza'], validationType, message);
+    return checkReturnedError(new MyClass(), ['aaaa', 'azzazza'], validationType, message);
   });
 });
 

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -946,26 +946,26 @@ describe('groups', () => {
     const model1 = new MyClass();
 
     it('should ignore decorators with groups if validating without groups', function () {
-      return validator.validate(model1, { strictGroups: true }).then(errors => {
+      return validator.validate(model1, { strictGroups: true, forbidUnknownValues: false }).then(errors => {
         expect(errors).toHaveLength(0);
       });
     });
 
     it('should ignore decorators with groups if validating with empty groups array', function () {
-      return validator.validate(model1, { strictGroups: true, groups: [] }).then(errors => {
+      return validator.validate(model1, { strictGroups: true, groups: [], forbidUnknownValues: false }).then(errors => {
         expect(errors).toHaveLength(0);
       });
     });
 
     it('should include decorators with groups if validating with matching groups', function () {
-      return validator.validate(model1, { strictGroups: true, groups: ['A'] }).then(errors => {
+      return validator.validate(model1, { strictGroups: true, groups: ['A'], forbidUnknownValues: false }).then(errors => {
         expect(errors).toHaveLength(1);
         expectTitleContains(errors[0]);
       });
     });
 
     it('should not include decorators with groups if validating with different groups', function () {
-      return validator.validate(model1, { strictGroups: true, groups: ['B'] }).then(errors => {
+      return validator.validate(model1, { strictGroups: true, groups: ['B'], forbidUnknownValues: false }).then(errors => {
         expect(errors).toHaveLength(0);
       });
     });

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -958,16 +958,20 @@ describe('groups', () => {
     });
 
     it('should include decorators with groups if validating with matching groups', function () {
-      return validator.validate(model1, { strictGroups: true, groups: ['A'], forbidUnknownValues: false }).then(errors => {
-        expect(errors).toHaveLength(1);
-        expectTitleContains(errors[0]);
-      });
+      return validator
+        .validate(model1, { strictGroups: true, groups: ['A'], forbidUnknownValues: false })
+        .then(errors => {
+          expect(errors).toHaveLength(1);
+          expectTitleContains(errors[0]);
+        });
     });
 
     it('should not include decorators with groups if validating with different groups', function () {
-      return validator.validate(model1, { strictGroups: true, groups: ['B'], forbidUnknownValues: false }).then(errors => {
-        expect(errors).toHaveLength(0);
-      });
+      return validator
+        .validate(model1, { strictGroups: true, groups: ['B'], forbidUnknownValues: false })
+        .then(errors => {
+          expect(errors).toHaveLength(0);
+        });
     });
   });
 

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -24,7 +24,7 @@ describe('validator options', () => {
       });
   });
 
-  test.each([[{ forbidUnknownValues: true }], [{}]])('should returns error on unknown objects with %s', (options)=>{
+  test.each([[{ forbidUnknownValues: true }], [{}]])('should returns error on unknown objects with %s', options => {
     const anonymousObject = { badKey: 'This should not pass.' };
 
     return validator.validate(anonymousObject, { ...options }).then(errors => {

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -24,10 +24,10 @@ describe('validator options', () => {
       });
   });
 
-  it('should returns error on unknown objects if forbidUnknownValues is true', function () {
+  test.each([[{ forbidUnknownValues: true }], [{}]])('should returns error on unknown objects with %s', (options)=>{
     const anonymousObject = { badKey: 'This should not pass.' };
 
-    return validator.validate(anonymousObject, { forbidUnknownValues: true }).then(errors => {
+    return validator.validate(anonymousObject, { ...options }).then(errors => {
       expect(errors.length).toEqual(1);
       expect(errors[0].target).toEqual(anonymousObject);
       expect(errors[0].property).toEqual(undefined);

--- a/test/functional/whitelist-validation.spec.ts
+++ b/test/functional/whitelist-validation.spec.ts
@@ -52,7 +52,7 @@ describe('whitelist validation', () => {
 
     model.unallowedProperty = 'non-whitelisted';
 
-    return validator.validate(model, { whitelist: true, forbidNonWhitelisted: true }).then(errors => {
+    return validator.validate(model, { whitelist: true, forbidNonWhitelisted: true, forbidUnknownValues: false }).then(errors => {
       expect(errors.length).toEqual(1);
       expect(errors[0].target).toEqual(model);
       expect(errors[0].property).toEqual('unallowedProperty');

--- a/test/functional/whitelist-validation.spec.ts
+++ b/test/functional/whitelist-validation.spec.ts
@@ -52,12 +52,14 @@ describe('whitelist validation', () => {
 
     model.unallowedProperty = 'non-whitelisted';
 
-    return validator.validate(model, { whitelist: true, forbidNonWhitelisted: true, forbidUnknownValues: false }).then(errors => {
-      expect(errors.length).toEqual(1);
-      expect(errors[0].target).toEqual(model);
-      expect(errors[0].property).toEqual('unallowedProperty');
-      expect(errors[0].constraints).toHaveProperty(ValidationTypes.WHITELIST);
-      expect(() => errors[0].toString()).not.toThrowError();
-    });
+    return validator
+      .validate(model, { whitelist: true, forbidNonWhitelisted: true, forbidUnknownValues: false })
+      .then(errors => {
+        expect(errors.length).toEqual(1);
+        expect(errors[0].target).toEqual(model);
+        expect(errors[0].property).toEqual('unallowedProperty');
+        expect(errors[0].constraints).toHaveProperty(ValidationTypes.WHITELIST);
+        expect(() => errors[0].toString()).not.toThrowError();
+      });
   });
 });


### PR DESCRIPTION
## Description
This is an attempted fix for https://github.com/typestack/class-validator/issues/438
It does so with a breaking change that uses a safe default of `true` for `forbidUnknownValues`. Only an explicit `false` value would preserve the previous default behaviour.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #438 

### Other
2f3f241ba52e065cd8bdc735c7ebeb3b3a6f5cde Moved `@types/validator` to `devDependencies`
6b5d1d567654d60da21cbdade8dc425b5c64f7fd Fixed a couple of tests that were not returning promises and failing silently