### PR TITLE
fix: IsPhoneNumber decorator did not validate correctly

### DIFF
--- a/src/decorator/string/IsPhoneNumber.ts
+++ b/src/decorator/string/IsPhoneNumber.ts
@@ -1,27 +1,8 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
-import { parsePhoneNumberFromString, CountryCode } from 'libphonenumber-js';
+import { isValidPhoneNumber, CountryCode } from 'libphonenumber-js';
 
 export const IS_PHONE_NUMBER = 'isPhoneNumber';
-
-/**
- * Checks if the string is a valid phone number. To successfully validate any phone number the text must include
- * the intl. calling code, if the calling code wont be provided then the region must be set.
- *
- * @param value the potential phone number string to test
- * @param region 2 characters uppercase country code (e.g. DE, US, CH) for country specific validation.
- * If text doesn't start with the international calling code (e.g. +41), then you must set this parameter.
- */
-export function isPhoneNumber(value: string, region?: CountryCode): boolean {
-  try {
-    const phoneNum = parsePhoneNumberFromString(value, region);
-    const result = phoneNum?.isValid();
-    return !!result;
-  } catch (error) {
-    // logging?
-    return false;
-  }
-}
 
 /**
  * Checks if the string is a valid phone number. To successfully validate any phone number the text must include
@@ -36,7 +17,7 @@ export function IsPhoneNumber(region?: CountryCode, validationOptions?: Validati
       name: IS_PHONE_NUMBER,
       constraints: [region],
       validator: {
-        validate: (value, args): boolean => isPhoneNumber(value, args?.constraints[0]),
+        validate: (value, args): boolean => isValidPhoneNumber(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a valid phone number',
           validationOptions


### PR DESCRIPTION
## Description
Strings with characters before or after a correct phone number were being passed as valid.

## Checklist
- [X] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [X] the pull request targets the *default* branch of the repository (`develop`)
- [X] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [X] I have run the project locally and verified that there are no errors
