### PR TITLE
fix: allow number and boolean values in validation message "$value" tokens

### DIFF
--- a/src/validation/ValidationUtils.ts
+++ b/src/validation/ValidationUtils.ts
@@ -40,7 +40,7 @@ export class ValidationUtils {
       messageString &&
       validationArguments.value !== undefined &&
       validationArguments.value !== null &&
-      typeof validationArguments.value === 'string'
+      ['string', 'boolean', 'number'].includes(typeof validationArguments.value)
     )
       messageString = messageString.replace(/\$value/g, validationArguments.value);
     if (messageString) messageString = messageString.replace(/\$property/g, validationArguments.property);

--- a/test/functional/validation-options.spec.ts
+++ b/test/functional/validation-options.spec.ts
@@ -1,7 +1,9 @@
 import {
   Contains,
+  Equals,
   IsDefined,
   Matches,
+  Max,
   MinLength,
   IsArray,
   Validate,
@@ -58,7 +60,7 @@ describe('message', () => {
     });
   });
 
-  it('$value token should be replaced in a custom message', () => {
+  it('$value token should be replaced in a custom message with a string', () => {
     class MyClass {
       @MinLength(2, {
         message: args => {
@@ -75,6 +77,38 @@ describe('message', () => {
     return validator.validate(model).then(errors => {
       expect(errors.length).toEqual(1);
       expect(errors[0].constraints).toEqual({ minLength: ' is too short, minimum length is 2 characters name' });
+    });
+  });
+
+  it('$value token should be replaced in a custom message with a number', () => {
+    class MyClass {
+      @Max(100, { message: 'Maximum value is $constraint1, but actual is $value' })
+      val: number = 50;
+    }
+
+    const model = new MyClass();
+    model.val = 101;
+    return validator.validate(model).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].constraints).toEqual({
+        max: 'Maximum value is 100, but actual is 101',
+      });
+    });
+  });
+
+  it('$value token should be replaced in a custom message with a boolean', () => {
+    class MyClass {
+      @Equals(true, { message: 'Value must be $constraint1, but actual is $value' })
+      val: boolean = false;
+    }
+
+    const model = new MyClass();
+    model.val = false;
+    return validator.validate(model).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].constraints).toEqual({
+        equals: 'Value must be true, but actual is false',
+      });
     });
   });
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
As reported in issues #921 and #1046, the `$value` token in validation message isn't replaced properly in some cases. It turns out that the `$value` token is parsed as expected only when the provided value is of type `string`, which results in commonly used validators with non-string values such as `@MinLength`, `@Min`, `@MaxLength`, `@Max` ect. to leave the `$value` token in the validation message without replacing it. This PR relaxes the runtime typecheck performed when constructing the validation message by allowing types `boolean` and `number` (alongside `string`) to act as `$value` token replacements.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
references #1046, references #921
