### PR TITLE
docs: correct typo in JSDoc for `@IsHalfWidth` decorator

### DIFF
--- a/src/decorator/string/IsHalfWidth.ts
+++ b/src/decorator/string/IsHalfWidth.ts
@@ -13,7 +13,7 @@ export function isHalfWidth(value: unknown): boolean {
 }
 
 /**
- * Checks if the string contains any full-width chars.
+ * Checks if the string contains any half-width chars.
  * If given value is not a string, then it returns false.
  */
 export function IsHalfWidth(validationOptions?: ValidationOptions): PropertyDecorator {


### PR DESCRIPTION
## Description

Correct the docblock content for the IsHalfWidth decorator which was referencing full-width

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #1545
