### PR TITLE
fix: read nullable option in `@IsNotEmptyObject` decorator correctly

### DIFF
--- a/src/decorator/object/IsNotEmptyObject.ts
+++ b/src/decorator/object/IsNotEmptyObject.ts
@@ -13,7 +13,7 @@ export function isNotEmptyObject(value: unknown, options?: { nullable?: boolean 
     return false;
   }
 
-  if (options?.nullable === true) {
+  if (options?.nullable === false) {
     return !Object.values(value).every(propertyValue => propertyValue === null || propertyValue === undefined);
   }
 

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -3225,8 +3225,8 @@ describe('IsNotEmptyObject', () => {
   });
 
   describe('with `nullable` option', () => {
-    const nullableValidValues = validValues
-    const nullableInvalidValues = invalidValues
+    const nullableValidValues = validValues;
+    const nullableInvalidValues = invalidValues;
     const nonNullableValidValues = [{ key: 'value' }, { key: 'value' }];
     const nonNullableInvalidValues = [
       null,
@@ -3270,7 +3270,7 @@ describe('IsNotEmptyObject', () => {
       nullableInvalidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: true })).toBeFalsy());
       nonNullableInvalidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: false })).toBeFalsy());
     });
-  })
+  });
 });
 
 describe('IsLowercase', () => {

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -3196,54 +3196,26 @@ describe('IsNotEmptyObject', () => {
     [],
     [{ key: 'value' }],
   ];
-  const nullableValidValues = [{ key: 'value' }, { key: 'value' }];
-  const nullableInvalidValues = [
-    null,
-    undefined,
-    '{ key: "value" }',
-    "{ 'key': 'value' }",
-    'string',
-    1234,
-    false,
-    {},
-    { key: undefined },
-    { key: null },
-    [],
-    [{ key: 'value' }],
-  ];
 
   class MyClass {
     @IsNotEmptyObject()
     someProperty: object;
   }
 
-  class NullableMyClass {
-    @IsNotEmptyObject({ nullable: true })
-    someProperty: object;
-  }
-
-  it.each([
-    [new MyClass(), validValues],
-    [new NullableMyClass(), nullableValidValues],
-  ])('should not fail if validator.validate said that its valid', (validationObject, values) => {
-    return checkValidValues(validationObject, values);
+  it('should not fail if validator.validate said that its valid', () => {
+    return checkValidValues(new MyClass(), validValues);
   });
 
-  it.each([
-    [new MyClass(), invalidValues],
-    [new NullableMyClass(), nullableInvalidValues],
-  ])('should fail if validator.validate said that its invalid', (validationObject, values) => {
-    return checkInvalidValues(validationObject, values);
+  it('should fail if validator.validate said that its invalid', () => {
+    return checkInvalidValues(new MyClass(), invalidValues);
   });
 
   it('should not fail if method in validator said that its valid', () => {
     validValues.forEach(value => expect(isNotEmptyObject(value)).toBeTruthy());
-    nullableValidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: true })).toBeTruthy());
   });
 
   it('should fail if method in validator said that its invalid', () => {
     invalidValues.forEach(value => expect(isNotEmptyObject(value)).toBeFalsy());
-    nullableInvalidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: true })).toBeFalsy());
   });
 
   it('should return error object with proper data', () => {
@@ -3251,6 +3223,54 @@ describe('IsNotEmptyObject', () => {
     const message = 'someProperty must be a non-empty object';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
+
+  describe('with `nullable` option', () => {
+    const nullableValidValues = validValues
+    const nullableInvalidValues = invalidValues
+    const nonNullableValidValues = [{ key: 'value' }, { key: 'value' }];
+    const nonNullableInvalidValues = [
+      null,
+      undefined,
+      '{ key: "value" }',
+      "{ 'key': 'value' }",
+      'string',
+      1234,
+      false,
+      {},
+      { key: undefined },
+      { key: null },
+      [],
+      [{ key: 'value' }],
+    ];
+    class NullableMyClass {
+      @IsNotEmptyObject({ nullable: true })
+      someProperty: object;
+    }
+    class NonNullableMyClass {
+      @IsNotEmptyObject({ nullable: false })
+      someProperty: object;
+    }
+
+    it('should not fail if validator.validate said that its valid', async () => {
+      await checkValidValues(new NullableMyClass(), nullableValidValues);
+      await checkValidValues(new NonNullableMyClass(), nonNullableValidValues);
+    });
+
+    it('should fail if validator.validate said that its valid', async () => {
+      await checkInvalidValues(new NullableMyClass(), nullableInvalidValues);
+      await checkInvalidValues(new NonNullableMyClass(), nonNullableInvalidValues);
+    });
+
+    it('should not fail if method in validator said that its valid', () => {
+      nullableValidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: true })).toBeTruthy());
+      nonNullableValidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: false })).toBeTruthy());
+    });
+
+    it('should fail if method in validator said that its invalid', () => {
+      nullableInvalidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: true })).toBeFalsy());
+      nonNullableInvalidValues.forEach(value => expect(isNotEmptyObject(value, { nullable: false })).toBeFalsy());
+    });
+  })
 });
 
 describe('IsLowercase', () => {


### PR DESCRIPTION
## Description

Fixing `@IsNotEmptyObject`-`nullable` option's behavior and test case.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #1554
