### PR TITLE
feat: add `@IsBase58` validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ isBoolean(value);
 | `@IsDecimal(options?: IsDecimalOptions)`        | Checks if the string is a valid decimal value. Default IsDecimalOptions are `force_decimal=False`, `decimal_digits: '1,'`, `locale: 'en-US'` |
 | `@IsAscii()`                                    | Checks if the string contains ASCII chars only. |
 | `@IsBase32()`                                   | Checks if a string is base32 encoded. |
+| `@IsBase58()`                                   | Checks if a string is base58 encoded. |
 | `@IsBase64()`                                   | Checks if a string is base64 encoded. |
 | `@IsIBAN()`                                     | Checks if a string is a IBAN (International Bank Account Number). |
 | `@IsBIC()`                                      | Checks if a string is a BIC (Bank Identification Code) or SWIFT code. |

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -113,6 +113,7 @@ export * from './string/IsRgbColor';
 export * from './string/IsSemVer';
 export * from './string/IsStrongPassword';
 export * from './string/IsTimeZone';
+export * from './string/IsBase58';
 
 // -------------------------------------------------------------------------
 // Type checkers

--- a/src/decorator/string/IsBase58.ts
+++ b/src/decorator/string/IsBase58.ts
@@ -1,0 +1,30 @@
+import { ValidationOptions } from '../ValidationOptions';
+import { buildMessage, ValidateBy } from '../common/ValidateBy';
+import isBase58Validator from 'validator/lib/isBase58';
+
+export const IS_BASE58 = 'isBase58';
+
+/**
+ * Checks if a string is base58 encoded.
+ * If given value is not a string, then it returns false.
+ */
+export function isBase58(value: unknown): boolean {
+  return typeof value === 'string' && isBase58Validator(value);
+}
+
+/**
+ * Checks if a string is base58 encoded.
+ * If given value is not a string, then it returns false.
+ */
+export function IsBase58(validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: IS_BASE58,
+      validator: {
+        validate: (value, args): boolean => isBase58(value),
+        defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be base58 encoded', validationOptions),
+      },
+    },
+    validationOptions
+  );
+}

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -188,6 +188,8 @@ import {
   isStrongPassword,
   IsStrongPasswordOptions,
   IsTimeZone,
+  IsBase58,
+  isBase58,
 } from '../../src/decorator/decorators';
 import { Validator } from '../../src/validation/Validator';
 import { ValidatorOptions } from '../../src/validation/ValidatorOptions';
@@ -4657,6 +4659,39 @@ describe('IsStrongPassword with options', () => {
   it('should return error object with proper data', () => {
     const validationType = 'isStrongPassword';
     const message = 'someProperty is not strong enough';
+    return checkReturnedError(new MyClass(), invalidValues, validationType, message);
+  });
+});
+
+describe('IsBase58', () => {
+  const constraint = '';
+  const validValues = ['4Fcj4ooZqEQiyH68xykKJFnwZbePBCxgTjwQVtce1VyS'];
+  const invalidValues = [null, undefined, 'my*name-isKinggodHoon'];
+
+  class MyClass {
+    @IsBase58()
+    someProperty: string;
+  }
+
+  it('should not fail if validator.validate said that its valid', () => {
+    return checkValidValues(new MyClass(), validValues);
+  });
+
+  it('should fail if validator.validate said that its invalid', () => {
+    return checkInvalidValues(new MyClass(), invalidValues);
+  });
+
+  it('should not fail if method in validator said that its valid', () => {
+    validValues.forEach(value => expect(isBase58(value)).toBeTruthy());
+  });
+
+  it('should fail if method in validator said that its invalid', () => {
+    invalidValues.forEach(value => expect(isBase58(value)).toBeFalsy());
+  });
+
+  it('should return error object with proper data', () => {
+    const validationType = 'isBase58';
+    const message = 'someProperty must be base58 encoded';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
   });
 });


### PR DESCRIPTION
### Description

Adds implementation for `@IsBase58` validator. It checks whether the given string is a valid Base58 encoded string or not.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

references #1821
