### PR TITLE
fix: use optional chaining in ValidationArguments before accessing their value

### DIFF
--- a/src/decorator/array/ArrayContains.ts
+++ b/src/decorator/array/ArrayContains.ts
@@ -23,7 +23,7 @@ export function ArrayContains(values: any[], validationOptions?: ValidationOptio
       name: ARRAY_CONTAINS,
       constraints: [values],
       validator: {
-        validate: (value, args): boolean => arrayContains(value, args.constraints[0]),
+        validate: (value, args): boolean => arrayContains(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must contain $constraint1 values',
           validationOptions

--- a/src/decorator/array/ArrayMaxSize.ts
+++ b/src/decorator/array/ArrayMaxSize.ts
@@ -21,7 +21,7 @@ export function ArrayMaxSize(max: number, validationOptions?: ValidationOptions)
       name: ARRAY_MAX_SIZE,
       constraints: [max],
       validator: {
-        validate: (value, args): boolean => arrayMaxSize(value, args.constraints[0]),
+        validate: (value, args): boolean => arrayMaxSize(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must contain not more than $constraint1 elements',
           validationOptions

--- a/src/decorator/array/ArrayMinSize.ts
+++ b/src/decorator/array/ArrayMinSize.ts
@@ -21,7 +21,7 @@ export function ArrayMinSize(min: number, validationOptions?: ValidationOptions)
       name: ARRAY_MIN_SIZE,
       constraints: [min],
       validator: {
-        validate: (value, args): boolean => arrayMinSize(value, args.constraints[0]),
+        validate: (value, args): boolean => arrayMinSize(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must contain at least $constraint1 elements',
           validationOptions

--- a/src/decorator/array/ArrayNotContains.ts
+++ b/src/decorator/array/ArrayNotContains.ts
@@ -23,7 +23,7 @@ export function ArrayNotContains(values: any[], validationOptions?: ValidationOp
       name: ARRAY_NOT_CONTAINS,
       constraints: [values],
       validator: {
-        validate: (value, args): boolean => arrayNotContains(value, args.constraints[0]),
+        validate: (value, args): boolean => arrayNotContains(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property should not contain $constraint1 values',
           validationOptions

--- a/src/decorator/common/Equals.ts
+++ b/src/decorator/common/Equals.ts
@@ -19,7 +19,7 @@ export function Equals(comparison: any, validationOptions?: ValidationOptions): 
       name: EQUALS,
       constraints: [comparison],
       validator: {
-        validate: (value, args): boolean => equals(value, args.constraints[0]),
+        validate: (value, args): boolean => equals(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be equal to $constraint1',
           validationOptions

--- a/src/decorator/common/IsIn.ts
+++ b/src/decorator/common/IsIn.ts
@@ -19,7 +19,7 @@ export function IsIn(values: readonly any[], validationOptions?: ValidationOptio
       name: IS_IN,
       constraints: [values],
       validator: {
-        validate: (value, args): boolean => isIn(value, args.constraints[0]),
+        validate: (value, args): boolean => isIn(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be one of the following values: $constraint1',
           validationOptions

--- a/src/decorator/common/IsNotIn.ts
+++ b/src/decorator/common/IsNotIn.ts
@@ -19,7 +19,7 @@ export function IsNotIn(values: readonly any[], validationOptions?: ValidationOp
       name: IS_NOT_IN,
       constraints: [values],
       validator: {
-        validate: (value, args): boolean => isNotIn(value, args.constraints[0]),
+        validate: (value, args): boolean => isNotIn(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property should not be one of the following values: $constraint1',
           validationOptions

--- a/src/decorator/common/NotEquals.ts
+++ b/src/decorator/common/NotEquals.ts
@@ -19,7 +19,7 @@ export function NotEquals(comparison: any, validationOptions?: ValidationOptions
       name: NOT_EQUALS,
       constraints: [comparison],
       validator: {
-        validate: (value, args): boolean => notEquals(value, args.constraints[0]),
+        validate: (value, args): boolean => notEquals(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property should not be equal to $constraint1',
           validationOptions

--- a/src/decorator/date/MaxDate.ts
+++ b/src/decorator/date/MaxDate.ts
@@ -19,7 +19,7 @@ export function MaxDate(date: Date, validationOptions?: ValidationOptions): Prop
       name: MAX_DATE,
       constraints: [date],
       validator: {
-        validate: (value, args): boolean => maxDate(value, args.constraints[0]),
+        validate: (value, args): boolean => maxDate(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => 'maximal allowed date for ' + eachPrefix + '$property is $constraint1',
           validationOptions

--- a/src/decorator/date/MinDate.ts
+++ b/src/decorator/date/MinDate.ts
@@ -19,7 +19,7 @@ export function MinDate(date: Date, validationOptions?: ValidationOptions): Prop
       name: MIN_DATE,
       constraints: [date],
       validator: {
-        validate: (value, args): boolean => minDate(value, args.constraints[0]),
+        validate: (value, args): boolean => minDate(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => 'minimal allowed date for ' + eachPrefix + '$property is $constraint1',
           validationOptions

--- a/src/decorator/number/IsDivisibleBy.ts
+++ b/src/decorator/number/IsDivisibleBy.ts
@@ -20,7 +20,7 @@ export function IsDivisibleBy(num: number, validationOptions?: ValidationOptions
       name: IS_DIVISIBLE_BY,
       constraints: [num],
       validator: {
-        validate: (value, args): boolean => isDivisibleBy(value, args.constraints[0]),
+        validate: (value, args): boolean => isDivisibleBy(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be divisible by $constraint1',
           validationOptions

--- a/src/decorator/number/Max.ts
+++ b/src/decorator/number/Max.ts
@@ -19,7 +19,7 @@ export function Max(maxValue: number, validationOptions?: ValidationOptions): Pr
       name: MAX,
       constraints: [maxValue],
       validator: {
-        validate: (value, args): boolean => max(value, args.constraints[0]),
+        validate: (value, args): boolean => max(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must not be greater than $constraint1',
           validationOptions

--- a/src/decorator/number/Min.ts
+++ b/src/decorator/number/Min.ts
@@ -19,7 +19,7 @@ export function Min(minValue: number, validationOptions?: ValidationOptions): Pr
       name: MIN,
       constraints: [minValue],
       validator: {
-        validate: (value, args): boolean => min(value, args.constraints[0]),
+        validate: (value, args): boolean => min(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must not be less than $constraint1',
           validationOptions

--- a/src/decorator/object/IsInstance.ts
+++ b/src/decorator/object/IsInstance.ts
@@ -24,10 +24,10 @@ export function IsInstance(
       name: IS_INSTANCE,
       constraints: [targetType],
       validator: {
-        validate: (value, args): boolean => isInstance(value, args.constraints[0]),
+        validate: (value, args): boolean => isInstance(value, args?.constraints[0]),
         defaultMessage: buildMessage((eachPrefix, args) => {
-          if (args.constraints[0]) {
-            return eachPrefix + `$property must be an instance of ${args.constraints[0].name as string}`;
+          if (args?.constraints[0]) {
+            return eachPrefix + `$property must be an instance of ${args?.constraints[0].name as string}`;
           } else {
             return eachPrefix + `${IS_INSTANCE} decorator expects and object as value, but got falsy value.`;
           }

--- a/src/decorator/object/IsNotEmptyObject.ts
+++ b/src/decorator/object/IsNotEmptyObject.ts
@@ -39,7 +39,7 @@ export function IsNotEmptyObject(
       name: IS_NOT_EMPTY_OBJECT,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isNotEmptyObject(value, args.constraints[0]),
+        validate: (value, args): boolean => isNotEmptyObject(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a non-empty object',
           validationOptions

--- a/src/decorator/string/Contains.ts
+++ b/src/decorator/string/Contains.ts
@@ -22,7 +22,7 @@ export function Contains(seed: string, validationOptions?: ValidationOptions): P
       name: CONTAINS,
       constraints: [seed],
       validator: {
-        validate: (value, args): boolean => contains(value, args.constraints[0]),
+        validate: (value, args): boolean => contains(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must contain a $constraint1 string',
           validationOptions

--- a/src/decorator/string/IsAlpha.ts
+++ b/src/decorator/string/IsAlpha.ts
@@ -23,7 +23,7 @@ export function IsAlpha(locale?: string, validationOptions?: ValidationOptions):
       name: IS_ALPHA,
       constraints: [locale],
       validator: {
-        validate: (value, args): boolean => isAlpha(value, args.constraints[0]),
+        validate: (value, args): boolean => isAlpha(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must contain only letters (a-zA-Z)',
           validationOptions

--- a/src/decorator/string/IsAlphanumeric.ts
+++ b/src/decorator/string/IsAlphanumeric.ts
@@ -23,7 +23,7 @@ export function IsAlphanumeric(locale?: string, validationOptions?: ValidationOp
       name: IS_ALPHANUMERIC,
       constraints: [locale],
       validator: {
-        validate: (value, args): boolean => isAlphanumeric(value, args.constraints[0]),
+        validate: (value, args): boolean => isAlphanumeric(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must contain only letters and numbers',
           validationOptions

--- a/src/decorator/string/IsByteLength.ts
+++ b/src/decorator/string/IsByteLength.ts
@@ -22,7 +22,7 @@ export function IsByteLength(min: number, max?: number, validationOptions?: Vali
       name: IS_BYTE_LENGTH,
       constraints: [min, max],
       validator: {
-        validate: (value, args): boolean => isByteLength(value, args.constraints[0], args.constraints[1]),
+        validate: (value, args): boolean => isByteLength(value, args?.constraints[0], args?.constraints[1]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + "$property's byte length must fall into ($constraint1, $constraint2) range",
           validationOptions

--- a/src/decorator/string/IsCurrency.ts
+++ b/src/decorator/string/IsCurrency.ts
@@ -26,7 +26,7 @@ export function IsCurrency(
       name: IS_CURRENCY,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isCurrency(value, args.constraints[0]),
+        validate: (value, args): boolean => isCurrency(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a currency', validationOptions),
       },
     },

--- a/src/decorator/string/IsDecimal.ts
+++ b/src/decorator/string/IsDecimal.ts
@@ -26,7 +26,7 @@ export function IsDecimal(
       name: IS_DECIMAL,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isDecimal(value, args.constraints[0]),
+        validate: (value, args): boolean => isDecimal(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property is not a valid decimal number.',
           validationOptions

--- a/src/decorator/string/IsEmail.ts
+++ b/src/decorator/string/IsEmail.ts
@@ -26,7 +26,7 @@ export function IsEmail(
       name: IS_EMAIL,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isEmail(value, args.constraints[0]),
+        validate: (value, args): boolean => isEmail(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be an email', validationOptions),
       },
     },

--- a/src/decorator/string/IsFQDN.ts
+++ b/src/decorator/string/IsFQDN.ts
@@ -23,7 +23,7 @@ export function IsFQDN(options?: ValidatorJS.IsFQDNOptions, validationOptions?: 
       name: IS_FQDN,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isFQDN(value, args.constraints[0]),
+        validate: (value, args): boolean => isFQDN(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a valid domain name',
           validationOptions

--- a/src/decorator/string/IsHash.ts
+++ b/src/decorator/string/IsHash.ts
@@ -25,7 +25,7 @@ export function IsHash(algorithm: string, validationOptions?: ValidationOptions)
       name: IS_HASH,
       constraints: [algorithm],
       validator: {
-        validate: (value, args): boolean => isHash(value, args.constraints[0]),
+        validate: (value, args): boolean => isHash(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a hash of type $constraint1',
           validationOptions

--- a/src/decorator/string/IsIP.ts
+++ b/src/decorator/string/IsIP.ts
@@ -26,7 +26,7 @@ export function IsIP(version?: IsIpVersion, validationOptions?: ValidationOption
       name: IS_IP,
       constraints: [version],
       validator: {
-        validate: (value, args): boolean => isIP(value, args.constraints[0]),
+        validate: (value, args): boolean => isIP(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be an ip address', validationOptions),
       },
     },

--- a/src/decorator/string/IsISBN.ts
+++ b/src/decorator/string/IsISBN.ts
@@ -26,7 +26,7 @@ export function IsISBN(version?: IsISBNVersion, validationOptions?: ValidationOp
       name: IS_ISBN,
       constraints: [version],
       validator: {
-        validate: (value, args): boolean => isISBN(value, args.constraints[0]),
+        validate: (value, args): boolean => isISBN(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be an ISBN', validationOptions),
       },
     },

--- a/src/decorator/string/IsISO8601.ts
+++ b/src/decorator/string/IsISO8601.ts
@@ -28,7 +28,7 @@ export function IsISO8601(
       name: IS_ISO8601,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isISO8601(value, args.constraints[0]),
+        validate: (value, args): boolean => isISO8601(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a valid ISO 8601 date string',
           validationOptions

--- a/src/decorator/string/IsISSN.ts
+++ b/src/decorator/string/IsISSN.ts
@@ -23,7 +23,7 @@ export function IsISSN(options?: ValidatorJS.IsISSNOptions, validationOptions?: 
       name: IS_ISSN,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isISSN(value, args.constraints[0]),
+        validate: (value, args): boolean => isISSN(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a ISSN', validationOptions),
       },
     },

--- a/src/decorator/string/IsIdentityCard.ts
+++ b/src/decorator/string/IsIdentityCard.ts
@@ -30,7 +30,7 @@ export function IsIdentityCard(
       name: IS_IDENTITY_CARD,
       constraints: [locale],
       validator: {
-        validate: (value, args): boolean => isIdentityCard(value, args.constraints[0]),
+        validate: (value, args): boolean => isIdentityCard(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a identity card number',
           validationOptions

--- a/src/decorator/string/IsMobilePhone.ts
+++ b/src/decorator/string/IsMobilePhone.ts
@@ -47,7 +47,7 @@ export function IsMobilePhone(
       name: IS_MOBILE_PHONE,
       constraints: [locale, options],
       validator: {
-        validate: (value, args): boolean => isMobilePhone(value, args.constraints[0], args.constraints[1]),
+        validate: (value, args): boolean => isMobilePhone(value, args?.constraints[0], args?.constraints[1]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a phone number', validationOptions),
       },
     },

--- a/src/decorator/string/IsNumberString.ts
+++ b/src/decorator/string/IsNumberString.ts
@@ -26,7 +26,7 @@ export function IsNumberString(
       name: IS_NUMBER_STRING,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isNumberString(value, args.constraints[0]),
+        validate: (value, args): boolean => isNumberString(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a number string', validationOptions),
       },
     },

--- a/src/decorator/string/IsPassportNumber.ts
+++ b/src/decorator/string/IsPassportNumber.ts
@@ -22,7 +22,7 @@ export function IsPassportNumber(countryCode: string, validationOptions?: Valida
       name: IS_PASSPORT_NUMBER,
       constraints: [countryCode],
       validator: {
-        validate: (value, args): boolean => isPassportNumber(value, args.constraints[0]),
+        validate: (value, args): boolean => isPassportNumber(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be valid passport number',
           validationOptions

--- a/src/decorator/string/IsPhoneNumber.ts
+++ b/src/decorator/string/IsPhoneNumber.ts
@@ -36,7 +36,7 @@ export function IsPhoneNumber(region?: CountryCode, validationOptions?: Validati
       name: IS_PHONE_NUMBER,
       constraints: [region],
       validator: {
-        validate: (value, args): boolean => isPhoneNumber(value, args.constraints[0]),
+        validate: (value, args): boolean => isPhoneNumber(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a valid phone number',
           validationOptions

--- a/src/decorator/string/IsPostalCode.ts
+++ b/src/decorator/string/IsPostalCode.ts
@@ -28,7 +28,7 @@ export function IsPostalCode(
       name: IS_POSTAL_CODE,
       constraints: [locale],
       validator: {
-        validate: (value, args): boolean => isPostalCode(value, args.constraints[0]),
+        validate: (value, args): boolean => isPostalCode(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a postal code', validationOptions),
       },
     },

--- a/src/decorator/string/IsRgbColor.ts
+++ b/src/decorator/string/IsRgbColor.ts
@@ -24,7 +24,7 @@ export function IsRgbColor(includePercentValues?: boolean, validationOptions?: V
       name: IS_RGB_COLOR,
       constraints: [includePercentValues],
       validator: {
-        validate: (value, args): boolean => isRgbColor(value, args.constraints[0]),
+        validate: (value, args): boolean => isRgbColor(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be RGB color', validationOptions),
       },
     },

--- a/src/decorator/string/IsUUID.ts
+++ b/src/decorator/string/IsUUID.ts
@@ -24,7 +24,7 @@ export function IsUUID(version?: UUIDVersion, validationOptions?: ValidationOpti
       name: IS_UUID,
       constraints: [version],
       validator: {
-        validate: (value, args): boolean => isUUID(value, args.constraints[0]),
+        validate: (value, args): boolean => isUUID(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be a UUID', validationOptions),
       },
     },

--- a/src/decorator/string/IsUrl.ts
+++ b/src/decorator/string/IsUrl.ts
@@ -23,7 +23,7 @@ export function IsUrl(options?: ValidatorJS.IsURLOptions, validationOptions?: Va
       name: IS_URL,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isURL(value, args.constraints[0]),
+        validate: (value, args): boolean => isURL(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be an URL address', validationOptions),
       },
     },

--- a/src/decorator/string/Length.ts
+++ b/src/decorator/string/Length.ts
@@ -22,13 +22,13 @@ export function Length(min: number, max?: number, validationOptions?: Validation
       name: IS_LENGTH,
       constraints: [min, max],
       validator: {
-        validate: (value, args): boolean => length(value, args.constraints[0], args.constraints[1]),
+        validate: (value, args): boolean => length(value, args?.constraints[0], args?.constraints[1]),
         defaultMessage: buildMessage((eachPrefix, args) => {
-          const isMinLength = args.constraints[0] !== null && args.constraints[0] !== undefined;
-          const isMaxLength = args.constraints[1] !== null && args.constraints[1] !== undefined;
-          if (isMinLength && (!args.value || args.value.length < args.constraints[0])) {
+          const isMinLength = args?.constraints[0] !== null && args?.constraints[0] !== undefined;
+          const isMaxLength = args?.constraints[1] !== null && args?.constraints[1] !== undefined;
+          if (isMinLength && (!args.value || args.value.length < args?.constraints[0])) {
             return eachPrefix + '$property must be longer than or equal to $constraint1 characters';
-          } else if (isMaxLength && args.value.length > args.constraints[1]) {
+          } else if (isMaxLength && args.value.length > args?.constraints[1]) {
             return eachPrefix + '$property must be shorter than or equal to $constraint2 characters';
           }
           return (

--- a/src/decorator/string/Matches.ts
+++ b/src/decorator/string/Matches.ts
@@ -37,7 +37,7 @@ export function Matches(
       name: MATCHES,
       constraints: [pattern, modifiers],
       validator: {
-        validate: (value, args): boolean => matches(value, args.constraints[0], args.constraints[1]),
+        validate: (value, args): boolean => matches(value, args?.constraints[0], args?.constraints[1]),
         defaultMessage: buildMessage(
           (eachPrefix, args) => eachPrefix + '$property must match $constraint1 regular expression',
           validationOptions

--- a/src/decorator/string/MaxLength.ts
+++ b/src/decorator/string/MaxLength.ts
@@ -22,7 +22,7 @@ export function MaxLength(max: number, validationOptions?: ValidationOptions): P
       name: MAX_LENGTH,
       constraints: [max],
       validator: {
-        validate: (value, args): boolean => maxLength(value, args.constraints[0]),
+        validate: (value, args): boolean => maxLength(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be shorter than or equal to $constraint1 characters',
           validationOptions

--- a/src/decorator/string/MinLength.ts
+++ b/src/decorator/string/MinLength.ts
@@ -22,7 +22,7 @@ export function MinLength(min: number, validationOptions?: ValidationOptions): P
       name: MIN_LENGTH,
       constraints: [min],
       validator: {
-        validate: (value, args): boolean => minLength(value, args.constraints[0]),
+        validate: (value, args): boolean => minLength(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be longer than or equal to $constraint1 characters',
           validationOptions

--- a/src/decorator/string/NotContains.ts
+++ b/src/decorator/string/NotContains.ts
@@ -22,7 +22,7 @@ export function NotContains(seed: string, validationOptions?: ValidationOptions)
       name: NOT_CONTAINS,
       constraints: [seed],
       validator: {
-        validate: (value, args): boolean => notContains(value, args.constraints[0]),
+        validate: (value, args): boolean => notContains(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property should not contain a $constraint1 string',
           validationOptions

--- a/src/decorator/typechecker/IsArray.ts
+++ b/src/decorator/typechecker/IsArray.ts
@@ -6,7 +6,7 @@ export const IS_ARRAY = 'isArray';
 /**
  * Checks if a given value is an array
  */
-export function isArray(value: unknown): boolean {
+export function isArray<T = any>(value: unknown): value is Array<T> {
   return Array.isArray(value);
 }
 

--- a/src/decorator/typechecker/IsBoolean.ts
+++ b/src/decorator/typechecker/IsBoolean.ts
@@ -6,7 +6,7 @@ export const IS_BOOLEAN = 'isBoolean';
 /**
  * Checks if a given value is a boolean.
  */
-export function isBoolean(value: unknown): boolean {
+export function isBoolean(value: unknown): value is boolean {
   return value instanceof Boolean || typeof value === 'boolean';
 }
 

--- a/src/decorator/typechecker/IsDate.ts
+++ b/src/decorator/typechecker/IsDate.ts
@@ -6,7 +6,7 @@ export const IS_DATE = 'isDate';
 /**
  * Checks if a given value is a date.
  */
-export function isDate(value: unknown): boolean {
+export function isDate(value: unknown): value is Date {
   return value instanceof Date && !isNaN(value.getTime());
 }
 

--- a/src/decorator/typechecker/IsEnum.ts
+++ b/src/decorator/typechecker/IsEnum.ts
@@ -8,7 +8,7 @@ export const IS_ENUM = 'isEnum';
  */
 export function isEnum(value: unknown, entity: any): boolean {
   const enumValues = Object.keys(entity).map(k => entity[k]);
-  return enumValues.indexOf(value) >= 0;
+  return enumValues.includes(value);
 }
 
 /**
@@ -20,7 +20,7 @@ export function IsEnum(entity: object, validationOptions?: ValidationOptions): P
       name: IS_ENUM,
       constraints: [entity],
       validator: {
-        validate: (value, args): boolean => isEnum(value, args.constraints[0]),
+        validate: (value, args): boolean => isEnum(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a valid enum value',
           validationOptions

--- a/src/decorator/typechecker/IsInt.ts
+++ b/src/decorator/typechecker/IsInt.ts
@@ -6,7 +6,7 @@ export const IS_INT = 'isInt';
 /**
  * Checks if value is an integer.
  */
-export function isInt(val: unknown): boolean {
+export function isInt(val: unknown): val is Number {
   return typeof val === 'number' && Number.isInteger(val);
 }
 

--- a/src/decorator/typechecker/IsNumber.ts
+++ b/src/decorator/typechecker/IsNumber.ts
@@ -15,17 +15,17 @@ export interface IsNumberOptions {
 /**
  * Checks if a given value is a number.
  */
-export function isNumber(value: unknown, options: IsNumberOptions = {}): boolean {
+export function isNumber(value: unknown, options: IsNumberOptions = {}): value is number {
   if (typeof value !== 'number') {
     return false;
   }
 
   if (value === Infinity || value === -Infinity) {
-    return options.allowInfinity;
+    return !!options.allowInfinity;
   }
 
   if (Number.isNaN(value)) {
-    return options.allowNaN;
+    return !!options.allowNaN;
   }
 
   if (options.maxDecimalPlaces !== undefined) {
@@ -50,7 +50,7 @@ export function IsNumber(options: IsNumberOptions = {}, validationOptions?: Vali
       name: IS_NUMBER,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isNumber(value, args.constraints[0]),
+        validate: (value, args): boolean => isNumber(value, args?.constraints[0]),
         defaultMessage: buildMessage(
           eachPrefix => eachPrefix + '$property must be a number conforming to the specified constraints',
           validationOptions

--- a/src/decorator/typechecker/IsObject.ts
+++ b/src/decorator/typechecker/IsObject.ts
@@ -7,7 +7,7 @@ export const IS_OBJECT = 'isObject';
  * Checks if the value is valid Object.
  * Returns false if the value is not an object.
  */
-export function isObject(value: unknown): value is object {
+export function isObject<T = object>(value: unknown): value is T {
   return value != null && (typeof value === 'object' || typeof value === 'function') && !Array.isArray(value);
 }
 

--- a/src/metadata/ValidationMetadata.ts
+++ b/src/metadata/ValidationMetadata.ts
@@ -72,7 +72,7 @@ export class ValidationMetadata {
     this.type = args.type;
     this.target = args.target;
     this.propertyName = args.propertyName;
-    this.constraints = args.constraints;
+    this.constraints = args?.constraints;
     this.constraintCls = args.constraintCls;
     this.validationTypeOptions = args.validationTypeOptions;
     if (args.validationOptions) {


### PR DESCRIPTION
## Description

This PR updates the access on validation arguments in each decorator to use the safe `args?.` format.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ ] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [ ] the pull request targets the *default* branch of the repository (`develop`)
- [ ] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
none