### PR TITLE
docs: add link to contribution guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Class-validator works on both browser and node.js platforms.
   - [Samples](#samples)
   - [Extensions](#extensions)
   - [Release notes](#release-notes)
+  - [Contributing](#contributing
 
 ## Installation
 
@@ -932,3 +933,7 @@ See information about breaking changes and release notes [here][3].
 [1]: https://github.com/chriso/validator.js
 [2]: https://github.com/pleerock/typedi
 [3]: CHANGELOG.md
+
+## Contributing
+
+For information about how to contribute to this project, see [TypeStack's general contribution guide]([url](https://github.com/typestack/.github/blob/master/CONTRIBUTING.md)).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Class-validator works on both browser and node.js platforms.
   - [Samples](#samples)
   - [Extensions](#extensions)
   - [Release notes](#release-notes)
-  - [Contributing](#contributing
+  - [Contributing](#contributing)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -936,4 +936,4 @@ See information about breaking changes and release notes [here][3].
 
 ## Contributing
 
-For information about how to contribute to this project, see [TypeStack's general contribution guide]([url](https://github.com/typestack/.github/blob/master/CONTRIBUTING.md)).
+For information about how to contribute to this project, see [TypeStack's general contribution guide](https://github.com/typestack/.github/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
## Description
Adds a new heading for contributing in the readme, which directs you to the existing contribution guideline under Typestack/.github

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors

### Fixes
fixes #1784
