### PR TITLE
feat: enable forbidUnknownValues by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ export interface ValidatorOptions {
 }
 ```
 
-> It's highly advised to set `forbidUnknownValues: true` as it will prevent unknown objects from passing validation.
+> **IMPORTANT**
+> The `forbidUnknownValues` value is set to `true` by default and **it is highly advised to keep the default**.
+> Setting it to `false` will result unknown objects passing the validation!
 
 ## Validation errors
 
@@ -523,6 +525,10 @@ for you, even if skipMissingProperties is set to true. For such cases you should
 
 In different situations you may want to use different validation schemas of the same object.
 In such cases you can use validation groups.
+
+> **IMPORTANT**
+> Calling a validation with a group combination that would not result in a validation (eg: non existent group name)
+> will result in a unknown value error. When validating with groups the provided group combination should match at least one decorator.
 
 ```typescript
 import { validate, Min, Length } from 'class-validator';

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -52,6 +52,9 @@ export class ValidationExecutor {
     const groups = this.validatorOptions ? this.validatorOptions.groups : undefined;
     const strictGroups = (this.validatorOptions && this.validatorOptions.strictGroups) || false;
     const always = (this.validatorOptions && this.validatorOptions.always) || false;
+    /** Forbid unknown values are turned on by default and any other value than false will enable it. */
+    const forbidUnknownValues =
+      this.validatorOptions?.forbidUnknownValues === undefined || this.validatorOptions.forbidUnknownValues !== false;
 
     const targetMetadatas = this.metadataStorage.getTargetValidationMetadatas(
       object.constructor,
@@ -62,7 +65,7 @@ export class ValidationExecutor {
     );
     const groupedMetadatas = this.metadataStorage.groupByPropertyName(targetMetadatas);
 
-    if (this.validatorOptions && this.validatorOptions.forbidUnknownValues && !targetMetadatas.length) {
+    if (this.validatorOptions && forbidUnknownValues && !targetMetadatas.length) {
       const validationError = new ValidationError();
 
       if (


### PR DESCRIPTION
## Description
This PR enables `forbidUnknownValues` by default. This is done to prevent objects pass validation when no check would be done on them. After this change is released any validated object that has no metadata associated with it will fail the validation. 

One notable example of this is validating with groups. If the called validation excludes all metadata due to the specified group then the validation will fail from now on instead of passing. Example:

```ts
class MyPayload {
    @IsString({ groups: ['A']})
    property: string;

    constructor(property: string) {
      this.property = property;
    }
}

validate(new MyPayload('value'), { groups: ['B'] }).then(console.log);
```
Calling the above will result in an error from now on:
```
[
  ValidationError {
    target: MyPayload { property: 'value' },
    value: undefined,
    property: undefined,
    children: [],
    constraints: {
      unknownValue: 'an unknown value was passed to the validate function'
    }
  }
]
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
references https://github.com/typestack/class-validator/issues/438, references https://github.com/typestack/class-validator/issues/1422
