### PR TITLE
feat: add `@IsISO4217CurrencyCode` decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ isBoolean(value);
 | `@IsByteLength(min: number, max?: number)`      | Checks if the string's length (in bytes) falls in a range. |
 | `@IsCreditCard()`                               | Checks if the string is a credit card. |
 | `@IsCurrency(options?: IsCurrencyOptions)`      | Checks if the string is a valid currency amount. |
+| `@IsISO4217CurrencyCode()`                      | Checks if the string is an ISO 4217 currency code. |
 | `@IsEthereumAddress()`                          | Checks if the string is an Ethereum address using basic regex. Does not validate address checksums. |
 | `@IsBtcAddress()`                               | Checks if the string is a valid BTC address. |
 | `@IsDataURI()`                                  | Checks if the string is a data uri format. |

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -115,6 +115,7 @@ export * from './string/IsStrongPassword';
 export * from './string/IsTimeZone';
 export * from './string/IsBase58';
 export * from './string/is-tax-id';
+export * from './string/is-iso4217-currency-code';
 
 // -------------------------------------------------------------------------
 // Type checkers

--- a/src/decorator/string/is-iso4217-currency-code.ts
+++ b/src/decorator/string/is-iso4217-currency-code.ts
@@ -1,0 +1,31 @@
+import { ValidationOptions } from '../ValidationOptions';
+import { buildMessage, ValidateBy } from '../common/ValidateBy';
+import isISO4217Validator from 'validator/lib/isISO4217';
+
+export const IS_ISO4217_CURRENCY_CODE = 'isISO4217CurrencyCode';
+
+/**
+ * Check if the string is a valid [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) officially assigned currency code.
+ */
+export function isISO4217CurrencyCode(value: unknown): boolean {
+  return typeof value === 'string' && isISO4217Validator(value);
+}
+
+/**
+ * Check if the string is a valid [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) officially assigned currency code.
+ */
+export function IsISO4217CurrencyCode(validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: IS_ISO4217_CURRENCY_CODE,
+      validator: {
+        validate: (value, args): boolean => isISO4217CurrencyCode(value),
+        defaultMessage: buildMessage(
+          eachPrefix => eachPrefix + '$property must be a valid ISO4217 currency code',
+          validationOptions
+        ),
+      },
+    },
+    validationOptions
+  );
+}

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -192,6 +192,7 @@ import {
   isBase58,
   isTaxId,
   IsTaxId,
+  IsISO4217CurrencyCode,
 } from '../../src/decorator/decorators';
 import { Validator } from '../../src/validation/Validator';
 import { ValidatorOptions } from '../../src/validation/ValidatorOptions';
@@ -4728,5 +4729,22 @@ describe('IsBase58', () => {
     const validationType = 'isBase58';
     const message = 'someProperty must be base58 encoded';
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
+  });
+});
+
+describe('IsISO4217', () => {
+  class MyClass {
+    @IsISO4217CurrencyCode()
+    someProperty: string;
+  }
+
+  it('should not fail for a valid ISO4217 code', () => {
+    const validValues = ['EUR', 'USD', 'BDT', 'LRD'];
+    return checkValidValues(new MyClass(), validValues);
+  });
+
+  it('should fail for invalid values', () => {
+    const invalidValues = [undefined, null, '', 'USS'];
+    return checkInvalidValues(new MyClass(), invalidValues);
   });
 });


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

This PR adds the `@IsISO4217CurrencyCode` decorator. This decorator checks if the give value is a valid official currency code according to the ISO4217 standard.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
references https://github.com/typestack/class-validator/issues/1549
