### PR TITLE
perf: store metadata in maps instead of arrays

### DIFF
--- a/src/metadata/MetadataStorage.ts
+++ b/src/metadata/MetadataStorage.ts
@@ -36,9 +36,9 @@ export class MetadataStorage {
    */
   addValidationMetadata(metadata: ValidationMetadata): void {
     const existingMetadata = this.validationMetadatas.get(metadata.target);
+
     if (existingMetadata) {
       existingMetadata.push(metadata);
-      this.validationMetadatas.set(metadata.target, existingMetadata);
     } else {
       this.validationMetadatas.set(metadata.target, [metadata]);
     }
@@ -49,9 +49,9 @@ export class MetadataStorage {
    */
   addConstraintMetadata(metadata: ConstraintMetadata): void {
     const existingMetadata = this.constraintMetadatas.get(metadata.target);
+
     if (existingMetadata) {
       existingMetadata.push(metadata);
-      this.constraintMetadatas.set(metadata.target, existingMetadata);
     } else {
       this.constraintMetadatas.set(metadata.target, [metadata]);
     }


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
From the original PR:
> This optimizes the performance of all validations and closes https://github.com/typestack/class-validator/issues/343.
>
> For example in my company we have 50+ complex models so `MetadatStorage.validationMetadatas` is array of ~5000 elements, `MetadatStorage.constraintMetadatas` is an array of 2500 elements. The validator loops over these arrays multiple times, so it takes 5+ seconds to validate a batch of 550 objects.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
references https://github.com/typestack/class-validator/issues/343
