### PR TITLE
fix: fail for non-array constraint in `@IsIn` decorator

### DIFF
--- a/src/decorator/common/IsIn.spec.ts
+++ b/src/decorator/common/IsIn.spec.ts
@@ -1,0 +1,17 @@
+import { isIn } from './IsIn';
+
+describe('@IsIn decorator implementation', () => {
+  describe('isIn validator', () => {
+    it('should accept valid values', () => {
+      expect(isIn('A', ['A', 'B'])).toBe(true);
+      expect(isIn('A', ['B', 'C'])).toBe(false);
+      expect(isIn('A', [1, 2])).toBe(false);
+    });
+
+    it('should not accept invalid values', () => {
+      expect(isIn('A', 5 as any)).toBe(false);
+      expect(isIn('A', 'ABC' as any)).toBe(false);
+      expect(isIn('A', false as any)).toBe(false);
+    });
+  });
+});

--- a/src/decorator/common/IsIn.ts
+++ b/src/decorator/common/IsIn.ts
@@ -7,7 +7,7 @@ export const IS_IN = 'isIn';
  * Checks if given value is in a array of allowed values.
  */
 export function isIn(value: unknown, possibleValues: readonly unknown[]): boolean {
-  return !Array.isArray(possibleValues) || possibleValues.some(possibleValue => possibleValue === value);
+  return Array.isArray(possibleValues) && possibleValues.some(possibleValue => possibleValue === value);
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

This PR fixes an error in `@IsIn` decorator that allowed values to pass validation when the constraint was not an array. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
references #1693
