### PR TITLE
docs: clarify meaning of stopAtFirstError option

### DIFF
--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -82,7 +82,9 @@ export interface ValidatorOptions {
   forbidUnknownValues?: boolean;
 
   /**
-   * When set to true, validation of the given property will stop after encountering the first error. Defaults to false.
+   * When set to true, validation of each property will stop after encountering its
+   * first error. Decorators with synchronous validation are evaluated in reverse order
+   * of appearance. Async validators have no guaranteed order. Defaults to false.
    */
   stopAtFirstError?: boolean;
 }


### PR DESCRIPTION
Some DOS attacks work by providing long strings that make the server work extra hard. stopAtFirstError can limit these attacks by preventing long strings from being parsed, but only if the dev knows the order in which decorators are validated. Stating the order also establishes a contract for ensuring backwards compatibility as the code evolves.

Proposed description:
```
  /**
   * When set to true, validation of each property will stop after encountering its
   * first error. Decorators with synchronous validation are evaluated in reverse order
   * of appearance. Async validators have no guaranteed order. Defaults to false.
   */
  stopAtFirstError?: boolean;
```

## Description
Only changes JSDoc to clarify usage of option

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
references #958, references #1688
