### PR TITLE
build: use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
+          cache: 'npm'
           registry-url: https://registry.npmjs.org
       - run: npm ci --ignore-scripts
       - run: npm run prettier:check

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
+          cache: 'npm'
       - run: npm ci --ignore-scripts
       - run: npm run prettier:check
       - run: npm run lint:check
@@ -25,6 +26,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm ci --ignore-scripts
       - run: npm run test:ci
       - run: npm install codecov -g
@@ -39,6 +41,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
+          cache: 'npm'
       - run: npm ci --ignore-scripts
       - run: npm run build:es2015
       - run: npm run build:esm5


### PR DESCRIPTION
## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action. 

### AS-IS

```yml
- uses: actions/setup-node@v3
  with:
    node-version: 'lts/*'
```

### TO-BE

```yml
- uses: actions/setup-node@v3
  with:
    node-version: 'lts/*'
    cache: 'npm'
```

> It’s literally a one line change to pass the `cache: 'npm'` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
