### PR TITLE
feat: Added a ISO639-1 decorator

### DIFF
--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -67,6 +67,7 @@ export * from './string/IsIP';
 export * from './string/IsPort';
 export * from './string/IsISBN';
 export * from './string/IsISIN';
+export * from './string/IsISO6391';
 export * from './string/IsISO8601';
 export * from './string/IsJSON';
 export * from './string/IsJWT';

--- a/src/decorator/string/IsISO6391.ts
+++ b/src/decorator/string/IsISO6391.ts
@@ -1,0 +1,33 @@
+import { ValidationOptions } from '../ValidationOptions';
+import { buildMessage, ValidateBy } from '../common/ValidateBy';
+import isISO6391 from 'validator/lib/isISO6391';
+
+export const IS_ISO6391 = 'isISO6391';
+
+/**
+ * Checks if the string is an ISO 639-1 (the country language code).
+ * If given value is not a string, then it returns false.
+ */
+export function isIso6391(value: unknown): boolean {
+  return typeof value === 'string' && isISO6391(value);
+}
+
+/**
+ * Checks if the string is an ISIN (stock/security identifier).
+ * If given value is not a string, then it returns false.
+ */
+export function IsISO6391(validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: IS_ISO6391,
+      validator: {
+        validate: (value, args): boolean => isIso6391(value),
+        defaultMessage: buildMessage(
+          eachPrefix => eachPrefix + '$property must be an ISO 639-1 (the country language code)',
+          validationOptions
+        ),
+      },
+    },
+    validationOptions
+  );
+}


### PR DESCRIPTION
This decorator is used to check if a string matches the ISO 639-1, that describes how country languages prefixes should look like.
Fortunatelly, it just delegates the validation to an already existent function in the validator library

This PR implements issue #2045 