### PR TITLE
feat: allow validate object literal (#1378)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Class-validator works on both browser and node.js platforms.
   - [Validating arrays](#validating-arrays)
   - [Validating sets](#validating-sets)
   - [Validating maps](#validating-maps)
+  - [Validating object literal](#validating-object-literal)
   - [Validating nested objects](#validating-nested-objects)
   - [Validating promises](#validating-promises)
   - [Inheriting Validation decorators](#inheriting-validation-decorators)
@@ -315,6 +316,25 @@ export class Post {
 ```
 
 This will validate each item in `post.tags` map.
+
+## Validating object literal
+
+If your field is a object literal and you want to perform validation of each item in the object you must specify a
+special `each: true` and `objectLiteral: true` decorator option:
+
+```typescript
+import { MaxLength } from 'class-validator';
+
+export class Post {
+  @MaxLength(20, {
+    each: true,
+    objectLiteral: true,
+  })
+  tags: Record<string, string>;
+}
+```
+
+This will validate each item in `post.tags` object.
 
 ## Validating nested objects
 

--- a/sample/sample10-object-literal/Post.ts
+++ b/sample/sample10-object-literal/Post.ts
@@ -1,0 +1,20 @@
+import { IsString, Length, ValidateNested } from '../../src/decorator/decorators';
+import { Tag } from './Tag';
+
+export class Post {
+  @Length(10, 20, {
+    message: 'Incorrect length!',
+  })
+  title: string;
+
+  @IsString({
+    each: true,
+    objectLiteral: true,
+  })
+  categories: Record<string, unknown>;
+
+  @ValidateNested({
+    objectLiteral: true,
+  })
+  tags: Record<string, Tag>;
+}

--- a/sample/sample10-object-literal/Tag.ts
+++ b/sample/sample10-object-literal/Tag.ts
@@ -1,0 +1,8 @@
+import { Length } from '../../src/decorator/decorators';
+
+export class Tag {
+  @Length(10, 20, {
+    message: 'Tag value is too short or long',
+  })
+  value: string;
+}

--- a/sample/sample10-object-literal/app.ts
+++ b/sample/sample10-object-literal/app.ts
@@ -1,0 +1,26 @@
+import { Validator } from '../../src/validation/Validator';
+import { Post } from './Post';
+import { Tag } from './Tag';
+
+let validator = new Validator();
+
+let tag1 = new Tag();
+tag1.value = 'ja';
+
+let tag2 = new Tag();
+tag2.value = 'node.js';
+
+let post1 = new Post();
+post1.title = 'Hello world';
+post1.categories = {
+  foo: 'bar',
+  bar: 123,
+};
+post1.tags = {
+  tag1,
+  tag2,
+};
+
+validator.validate(post1).then(result => {
+  console.log('1. should not pass: ', result);
+});

--- a/src/decorator/ValidationOptions.ts
+++ b/src/decorator/ValidationOptions.ts
@@ -5,6 +5,17 @@ import { ValidationArguments } from '../validation/ValidationArguments';
  */
 export interface ValidationOptions {
   /**
+   * Indicates that an object is to be considered object literal record.
+   *
+   * For an object-valued property marked as object literal, the object the property holds may neither
+   * be specifically class-typed nor validated, but all the child values of said object MUST be.
+   * Effectively, this declares object literal, which will be validated the same way any other
+   * JavaScript collection does (Array, Map, Set, etc).
+   * The default is `false`; that is, an object-value must be an instance of a class.
+   */
+  objectLiteral?: boolean;
+
+  /**
    * Specifies if validated value is an array and each of its items must be validated.
    */
   each?: boolean;
@@ -35,5 +46,12 @@ export function isValidationOptions(val: any): val is ValidationOptions {
   if (!val) {
     return false;
   }
-  return 'each' in val || 'message' in val || 'groups' in val || 'always' in val || 'context' in val;
+  return (
+    'objectLiteral' in val ||
+    'each' in val ||
+    'message' in val ||
+    'groups' in val ||
+    'always' in val ||
+    'context' in val
+  );
 }

--- a/src/metadata/ValidationMetadata.ts
+++ b/src/metadata/ValidationMetadata.ts
@@ -55,6 +55,17 @@ export class ValidationMetadata {
   always?: boolean;
 
   /**
+   * Indicates that an object is to be considered object literal record.
+   *
+   * For an object-valued property marked as object literal, the object the property holds may neither
+   * be specifically class-typed nor validated, but all the child values of said object MUST be.
+   * Effectively, this declares object literal, which will be validated the same way any other
+   * JavaScript collection does (Array, Map, Set, etc).
+   * The default is `false`; that is, an object-value must be an instance of a class.
+   */
+  objectLiteral: boolean = false;
+
+  /**
    * Specifies if validated value is an array and each of its item must be validated.
    */
   each: boolean = false;
@@ -85,6 +96,7 @@ export class ValidationMetadata {
       this.message = args.validationOptions.message;
       this.groups = args.validationOptions.groups;
       this.always = args.validationOptions.always;
+      this.objectLiteral = args.validationOptions.objectLiteral;
       this.each = args.validationOptions.each;
       this.context = args.validationOptions.context;
     }

--- a/src/utils/convert-to-array.util.ts
+++ b/src/utils/convert-to-array.util.ts
@@ -1,9 +1,16 @@
+import { isObjectLiteral } from './is-object-literal.util';
+
 /**
  * Convert Map, Set to Array
  */
-export function convertToArray<T>(val: Array<T> | Set<T> | Map<any, T>): Array<T> {
+export function convertToArray<T>(val: Array<T> | Set<T> | Map<any, T> | Record<keyof any, T>): Array<T> {
   if (val instanceof Map) {
     return Array.from(val.values());
   }
+
+  if (isObjectLiteral(val)) {
+    return Object.values(val);
+  }
+
   return Array.isArray(val) ? val : Array.from(val);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './convert-to-array.util';
 export * from './get-global.util';
+export * from './is-object-literal.util';
 export * from './is-promise.util';

--- a/src/utils/is-object-literal.util.ts
+++ b/src/utils/is-object-literal.util.ts
@@ -1,0 +1,3 @@
+export function isObjectLiteral(v: any): v is Record<keyof any, any> | any {
+  return !!v && v.constructor === Object;
+}

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -23,6 +23,18 @@ describe('convertToArray', () => {
     expect(newArr).toContain('world');
   });
 
+  it('convert Literal Object into array of values', () => {
+    const object = {
+      key1: 'hello',
+      key2: 'world',
+    };
+    const newArr = convertToArray(object);
+    expect(newArr).toBeInstanceOf(Array);
+    expect(newArr.length).toEqual(2);
+    expect(newArr).toContain('hello');
+    expect(newArr).toContain('world');
+  });
+
   it('should return array untouched', () => {
     const arr = ['hello', 'world'];
     expect(arr).toBeInstanceOf(Array);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,4 +1,4 @@
-import { convertToArray } from '../src/utils';
+import { convertToArray, isObjectLiteral } from '../src/utils';
 
 describe('convertToArray', () => {
   it('convert Set into array', () => {
@@ -29,5 +29,45 @@ describe('convertToArray', () => {
     expect(arr.length).toEqual(2);
     expect(arr).toContain('hello');
     expect(arr).toContain('world');
+  });
+});
+
+describe('isObjectLiteral', () => {
+  it('check is object is object literal', () => {
+    expect(
+      isObjectLiteral({
+        foo: 'bar',
+        bar: 'foo',
+      })
+    ).toEqual(true);
+  });
+
+  it('check is Object is object literal', () => {
+    expect(
+      isObjectLiteral(
+        new Object({
+          foo: 'bar',
+          bar: 'foo',
+        })
+      )
+    ).toEqual(true);
+  });
+
+  it("check is array isn't object literal", () => {
+    expect(isObjectLiteral(['foo', 'bar'])).toEqual(false);
+  });
+
+  it("check is Date isn't object literal", () => {
+    expect(isObjectLiteral(new Date())).toEqual(false);
+  });
+
+  it("check is custom class isn't object literal", () => {
+    class Foo {
+      bar: string;
+    }
+    const fooInstance = new Foo();
+    fooInstance.bar = 'baz';
+
+    expect(isObjectLiteral(fooInstance)).toEqual(false);
   });
 });


### PR DESCRIPTION
## Description
Add possibility to validate object literal with all decorators inclusive `@ValidateNested`. Base solution for this issue is from [flisboac](https://github.com/flisboac).

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #1378