### PR TITLE
Remove functions from enum values

### DIFF
--- a/src/decorator/typechecker/IsEnum.ts
+++ b/src/decorator/typechecker/IsEnum.ts
@@ -17,6 +17,7 @@ export function isEnum(value: unknown, entity: any): boolean {
 function validEnumValues(entity: any): string[] {
   return Object.entries(entity)
     .filter(([key, value]) => isNaN(parseInt(key)))
+    .filter(([key, value]) => typeof value !== 'function')
     .map(([key, value]) => value as string);
 }
 

--- a/src/decorator/typechecker/IsEnum.ts
+++ b/src/decorator/typechecker/IsEnum.ts
@@ -15,9 +15,7 @@ export function isEnum(value: unknown, entity: any): boolean {
  * Returns the possible values from an enum (both simple number indexed and string indexed enums).
  */
 function validEnumValues(entity: any): string[] {
-  return Object.entries(entity)
-    .filter(([key, value]) => typeof value === 'string' && isNaN(parseInt(key)))
-    .map(([key, value]) => value as string);
+  return Object.values(entity).filter(value => typeof value === 'string') as string[];
 }
 
 /**

--- a/src/decorator/typechecker/IsEnum.ts
+++ b/src/decorator/typechecker/IsEnum.ts
@@ -16,8 +16,7 @@ export function isEnum(value: unknown, entity: any): boolean {
  */
 function validEnumValues(entity: any): string[] {
   return Object.entries(entity)
-    .filter(([key, value]) => isNaN(parseInt(key)))
-    .filter(([key, value]) => typeof value !== 'function')
+    .filter(([key, value]) => typeof value === 'string' && isNaN(parseInt(key)))
     .map(([key, value]) => value as string);
 }
 


### PR DESCRIPTION
## Description
This change removes function declarations from enum values.

I am using an enum with an companion namespace with utility functions:
```typescript
export enum ResponseTypeEnum {
  Code = 'code',
}

export namespace ResponseTypeEnum {
  export const fromString = (value: string): ResponseTypeEnum => {
    switch (value.toLowerCase()) {
      case 'code':
        return ResponseTypeEnum.Code
      default:
        throw Error('Invalid response type: ' + value)
    }
  }
}
```

Within a request body as such:
```typescript
export class Request {
  @IsEnum(ResponseTypeEnum)
  responseType: ResponseTypeEnum
}
```

The error returned by the server upon sending an invalid enum value is serialized as the following:
```
"responseType must be one of the following values: code, (value) => {\n        switch (value.toLowerCase()) {\n            case 'code':\n                return ResponseTypeEnum.Code;\n            default:\n                throw Error('Invalid response type: ' + value);\n        }\n    }"
```

This PR removes the function declaration from the possible enum values in the error message

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
