### PR TITLE
refactor: more concise typings for `isDefined` utility function

### DIFF
--- a/src/decorator/common/IsDefined.ts
+++ b/src/decorator/common/IsDefined.ts
@@ -8,7 +8,7 @@ export const IS_DEFINED = ValidationTypes.IS_DEFINED;
 /**
  * Checks if value is defined (!== undefined, !== null).
  */
-export function isDefined(value: any): boolean {
+export function isDefined<T>(value: T | undefined | null): value is T {
   return value !== undefined && value !== null;
 }
 


### PR DESCRIPTION
## Description
When using the utility function `isDefined`, typescript can properly ignore undefined and null with stricter typing.

## Example
```js
function example(param?: string) {
  if (!isDefined(param)) return
  console.log(param.charAt(0)) // Typescript now knows that param _must_ be a string and does not throw a warning param might be undefined
}
```

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified → _it wasn't_ )
- [x] documentation added or updated ← _stays the same_
- [x] I have run the project locally and verified that there are no errors

### Fixes
This change is so simple, I hoped we don't need to clutter the issue tracker. If you want me to open a feature request, I'll gladly do so.