### PR TITLE
Patch IsNumber decorator with maxDecimalPlaces option set for numbers in scientific annotation

### DIFF
--- a/src/decorator/typechecker/IsNumber.ts
+++ b/src/decorator/typechecker/IsNumber.ts
@@ -29,11 +29,7 @@ export function isNumber(value: unknown, options: IsNumberOptions = {}): value i
   }
 
   if (options.maxDecimalPlaces !== undefined) {
-    let decimalPlaces = 0;
-    if (value % 1 !== 0) {
-      decimalPlaces = value.toFixed(options.maxDecimalPlaces).split('.')[1].length;
-    }
-    if (decimalPlaces > options.maxDecimalPlaces) {
+    if (parseFloat(value.toFixed(options.maxDecimalPlaces)) !== value) {
       return false;
     }
   }

--- a/src/decorator/typechecker/IsNumber.ts
+++ b/src/decorator/typechecker/IsNumber.ts
@@ -29,8 +29,10 @@ export function isNumber(value: unknown, options: IsNumberOptions = {}): value i
   }
 
   if (options.maxDecimalPlaces !== undefined) {
-    if (parseFloat(value.toFixed(options.maxDecimalPlaces)) !== value) {
-      return false;
+    if (value % 1 !== 0) {
+      if (parseFloat(value.toFixed(options.maxDecimalPlaces)) !== value) {
+        return false;
+      }
     }
   }
 

--- a/src/decorator/typechecker/IsNumber.ts
+++ b/src/decorator/typechecker/IsNumber.ts
@@ -31,7 +31,7 @@ export function isNumber(value: unknown, options: IsNumberOptions = {}): value i
   if (options.maxDecimalPlaces !== undefined) {
     let decimalPlaces = 0;
     if (value % 1 !== 0) {
-      decimalPlaces = value.toString().split('.')[1].length;
+      decimalPlaces = value.toFixed(options.maxDecimalPlaces).split('.')[1].length;
     }
     if (decimalPlaces > options.maxDecimalPlaces) {
       return false;


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
The **IsNumber()** decorator doesn't work on scientifically annotated numbers when specifying `maxDecimalPlaces` option because `value.toString()` has no dot in it and crashes (see issue: https://github.com/typestack/class-validator/issues/1705).

https://github.com/typestack/class-validator/blob/4a0ec6680161fc611ba9fdea74fd34653c3997e6/src/decorator/typechecker/IsNumber.ts#L34

This patch reworks the whole handling of `maxDecimalPlaces` option in order to make it work with scientific numbers.

The logic behind the patch is `toFixed(maxDecimalPlaces)` the input so it is represented as a string with a maximum number of decimals as specified by the option `maxDecimalPlaces`, then `parseFloat()` it to be compared with the original input.
If there is a difference with the original input, it means it has a number of decimals > `maxDecimalPlaces` because they have been truncated by `toFixed(maxDecimalPlaces)`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [ ] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1705 