### PR TITLE
fix: forbidUnknownValues should default true when validatorOptions undefined

### DIFF
--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -67,7 +67,7 @@ export class ValidationExecutor {
     );
     const groupedMetadatas = this.metadataStorage.groupByPropertyName(targetMetadatas);
 
-    if (this.validatorOptions && forbidUnknownValues && !targetMetadatas.length) {
+    if (forbidUnknownValues && !targetMetadatas.length) {
       const validationError = new ValidationError();
 
       if (

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -72,10 +72,10 @@ export interface ValidatorOptions {
   };
 
   /**
-   * Fails validation for objects unknown to class-validator. Defaults to false.
+   * Fails validation for objects unknown to class-validator. Defaults to true.
    *
    * For instance, since a plain empty object has no annotations used for validation:
-   * - `validate({})` // passes
+   * - `validate({})` // fails.
    * - `validate({}, { forbidUnknownValues: true })` // fails.
    * - `validate(new SomeAnnotatedEmptyClass(), { forbidUnknownValues: true })` // passes.
    */

--- a/src/validation/ValidatorOptions.ts
+++ b/src/validation/ValidatorOptions.ts
@@ -77,6 +77,7 @@ export interface ValidatorOptions {
    * For instance, since a plain empty object has no annotations used for validation:
    * - `validate({})` // fails.
    * - `validate({}, { forbidUnknownValues: true })` // fails.
+   * - `validate({}, { forbidUnknownValues: false })` // passes.
    * - `validate(new SomeAnnotatedEmptyClass(), { forbidUnknownValues: true })` // passes.
    */
   forbidUnknownValues?: boolean;

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -44,4 +44,9 @@ describe('validator options', () => {
       expect(errors.length).toEqual(0);
     });
   });
+
+  it(`should forbidUnknownValues by default`, function () {
+    expect(validator.validateSync({}).length).toEqual(1);
+    expect(validator.validateSync({}, {}).length).toEqual(1);
+  });
 });

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -8,20 +8,23 @@ describe('validator options', () => {
     class MyClass {
       @IsNotEmpty()
       title: string = '';
+      isActive: boolean;
     }
 
     const model = new MyClass();
     model.title = '';
-    return validator.validate(model, { validationError: { target: false } }).then(errors => {
-      expect(errors.length).toEqual(1);
-      expect(errors[0].target).toBeUndefined();
-      expect(errors[0].property).toEqual('title');
-      expect(errors[0].constraints).toEqual({ isNotEmpty: 'title should not be empty' });
-      expect(errors[0].value).toEqual('');
-    });
+    return validator
+      .validate(model, { skipMissingProperties: true, validationError: { target: false } })
+      .then(errors => {
+        expect(errors.length).toEqual(1);
+        expect(errors[0].target).toBeUndefined();
+        expect(errors[0].property).toEqual('title');
+        expect(errors[0].constraints).toEqual({ isNotEmpty: 'title should not be empty' });
+        expect(errors[0].value).toEqual('');
+      });
   });
 
-  it('should return error on unknown objects if forbidUnknownValues is true', () => {
+  it('should returns error on unknown objects if forbidUnknownValues is true', function () {
     const anonymousObject = { badKey: 'This should not pass.' };
 
     return validator.validate(anonymousObject, { forbidUnknownValues: true }).then(errors => {
@@ -34,7 +37,7 @@ describe('validator options', () => {
     });
   });
 
-  it('should return no error on unknown objects if forbidUnknownValues is false', () => {
+  it('should return no error on unknown objects if forbidUnknownValues is false', function () {
     const anonymousObject = { badKey: 'This should not pass.' };
 
     return validator.validate(anonymousObject, { forbidUnknownValues: false }).then(errors => {

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -55,6 +55,19 @@ describe('validator options', () => {
     });
   });
 
+  it(`should return error on unknown objects if empty options object argument passed`, () => {
+    const anonymousObject = { badKey: 'This should not pass.' };
+
+    return validator.validate(anonymousObject, {}).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].target).toEqual(anonymousObject);
+      expect(errors[0].property).toEqual(undefined);
+      expect(errors[0].value).toEqual(undefined);
+      expect(errors[0].children).toBeInstanceOf(Array);
+      expect(errors[0].constraints).toEqual({ unknownValue: 'an unknown value was passed to the validate function' });
+    });
+  });
+
   it(`should return error on unknown objects if options object argument passed with forbidUnknownValues undefined`, () => {
     const anonymousObject = { badKey: 'This should not pass.' };
 

--- a/test/functional/validator-options.spec.ts
+++ b/test/functional/validator-options.spec.ts
@@ -8,23 +8,20 @@ describe('validator options', () => {
     class MyClass {
       @IsNotEmpty()
       title: string = '';
-      isActive: boolean;
     }
 
     const model = new MyClass();
     model.title = '';
-    return validator
-      .validate(model, { skipMissingProperties: true, validationError: { target: false } })
-      .then(errors => {
-        expect(errors.length).toEqual(1);
-        expect(errors[0].target).toBeUndefined();
-        expect(errors[0].property).toEqual('title');
-        expect(errors[0].constraints).toEqual({ isNotEmpty: 'title should not be empty' });
-        expect(errors[0].value).toEqual('');
-      });
+    return validator.validate(model, { validationError: { target: false } }).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].target).toBeUndefined();
+      expect(errors[0].property).toEqual('title');
+      expect(errors[0].constraints).toEqual({ isNotEmpty: 'title should not be empty' });
+      expect(errors[0].value).toEqual('');
+    });
   });
 
-  it('should returns error on unknown objects if forbidUnknownValues is true', function () {
+  it('should return error on unknown objects if forbidUnknownValues is true', () => {
     const anonymousObject = { badKey: 'This should not pass.' };
 
     return validator.validate(anonymousObject, { forbidUnknownValues: true }).then(errors => {
@@ -37,7 +34,7 @@ describe('validator options', () => {
     });
   });
 
-  it('should return no error on unknown objects if forbidUnknownValues is false', function () {
+  it('should return no error on unknown objects if forbidUnknownValues is false', () => {
     const anonymousObject = { badKey: 'This should not pass.' };
 
     return validator.validate(anonymousObject, { forbidUnknownValues: false }).then(errors => {
@@ -45,8 +42,29 @@ describe('validator options', () => {
     });
   });
 
-  it(`should forbidUnknownValues by default`, function () {
-    expect(validator.validateSync({}).length).toEqual(1);
-    expect(validator.validateSync({}, {}).length).toEqual(1);
+  it(`should return error on unknown objects if no options object argument is passed`, () => {
+    const anonymousObject = { badKey: 'This should not pass.' };
+
+    return validator.validate(anonymousObject, undefined).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].target).toEqual(anonymousObject);
+      expect(errors[0].property).toEqual(undefined);
+      expect(errors[0].value).toEqual(undefined);
+      expect(errors[0].children).toBeInstanceOf(Array);
+      expect(errors[0].constraints).toEqual({ unknownValue: 'an unknown value was passed to the validate function' });
+    });
+  });
+
+  it(`should return error on unknown objects if options object argument passed with forbidUnknownValues undefined`, () => {
+    const anonymousObject = { badKey: 'This should not pass.' };
+
+    return validator.validate(anonymousObject, { forbidUnknownValues: undefined }).then(errors => {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].target).toEqual(anonymousObject);
+      expect(errors[0].property).toEqual(undefined);
+      expect(errors[0].value).toEqual(undefined);
+      expect(errors[0].children).toBeInstanceOf(Array);
+      expect(errors[0].constraints).toEqual({ unknownValue: 'an unknown value was passed to the validate function' });
+    });
   });
 });


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
`forbidUnknownValues` is supposed to default to `true`. This wasn't the case when `validatorOptions` was `undefined`. This PR corrects that and adds a test for it. It also corrects some related code doc.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1906
