### PR TITLE
feat: access the node instance in custom validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,8 @@ If you have custom validation logic you can create a _Constraint class_:
    which defines validation logic. If validation succeeds, method returns true, otherwise false.
    Custom validator can be asynchronous, if you want to perform validation after some asynchronous
    operations, simply return a promise with boolean inside in `validate` method.
+   `ValidationArguments` contains useful information about validation process, like object that is being validated,
+   or the current object instance to validate value based on parent nodes.
 
    Also we defined optional method `defaultMessage` which defines a default error message,
    in the case that the decorator's implementation doesn't set an error message.

--- a/src/validation/ValidationArguments.ts
+++ b/src/validation/ValidationArguments.ts
@@ -24,6 +24,11 @@ export interface ValidationArguments {
   object: object;
 
   /**
+   * Instance of the object being validated.
+   */
+  instance: object;
+
+  /**
    * Name of the object's property being validated.
    */
   property: string;

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -269,12 +269,13 @@ export class ValidationExecutor {
           targetName: object.constructor ? (object.constructor as any).name : undefined,
           property: metadata.propertyName,
           object: object,
+          instance: this.instance,
           value: value,
           constraints: metadata.constraints,
         };
 
         if (!metadata.each || !(Array.isArray(value) || value instanceof Set || value instanceof Map)) {
-          const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments, this.instance);
+          const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments);
           if (isPromise(validatedValue)) {
             const promise = validatedValue.then(isValid => {
               if (!isValid) {
@@ -303,7 +304,7 @@ export class ValidationExecutor {
         const arrayValue = convertToArray(value);
         // Validation needs to be applied to each array item
         const validatedSubValues = arrayValue.map((subValue: any) =>
-          customConstraintMetadata.instance.validate(subValue, validationArguments, this.instance)
+          customConstraintMetadata.instance.validate(subValue, validationArguments)
         );
         const validationIsAsync = validatedSubValues.some((validatedSubValue: boolean | Promise<boolean>) =>
           isPromise(validatedSubValue)
@@ -411,6 +412,7 @@ export class ValidationExecutor {
       property: metadata.propertyName,
       object: object,
       value: value,
+      instance: this.instance,
       constraints: metadata.constraints,
     };
 

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -24,6 +24,7 @@ export class ValidationExecutor {
   // Private Properties
   // -------------------------------------------------------------------------
 
+  private instance: any = undefined;
   private metadataStorage = getMetadataStorage();
 
   // -------------------------------------------------------------------------
@@ -49,6 +50,11 @@ export class ValidationExecutor {
           `  - There may be multiple class-validator versions installed. You will need to flatten your dependencies to fix the issue.\n` +
           `  - This validation runs before any file with validation decorator was parsed by NodeJS.`
       );
+    }
+
+    // Keep the instance to the original object
+    if (this.instance === undefined){
+      this.instance = object;
     }
 
     const groups = this.validatorOptions ? this.validatorOptions.groups : undefined;
@@ -268,7 +274,7 @@ export class ValidationExecutor {
         };
 
         if (!metadata.each || !(Array.isArray(value) || value instanceof Set || value instanceof Map)) {
-          const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments);
+          const validatedValue = customConstraintMetadata.instance.validate(value, validationArguments, this.instance);
           if (isPromise(validatedValue)) {
             const promise = validatedValue.then(isValid => {
               if (!isValid) {
@@ -297,7 +303,7 @@ export class ValidationExecutor {
         const arrayValue = convertToArray(value);
         // Validation needs to be applied to each array item
         const validatedSubValues = arrayValue.map((subValue: any) =>
-          customConstraintMetadata.instance.validate(subValue, validationArguments)
+          customConstraintMetadata.instance.validate(subValue, validationArguments, this.instance)
         );
         const validationIsAsync = validatedSubValues.some((validatedSubValue: boolean | Promise<boolean>) =>
           isPromise(validatedSubValue)

--- a/src/validation/ValidatorConstraintInterface.ts
+++ b/src/validation/ValidatorConstraintInterface.ts
@@ -6,7 +6,7 @@ export interface ValidatorConstraintInterface {
   /**
    * Method to be called to perform custom validation over given value.
    */
-  validate(value: any, validationArguments?: ValidationArguments): Promise<boolean> | boolean;
+  validate(value: any, validationArguments?: ValidationArguments, instance?: any): Promise<boolean> | boolean;
 
   /**
    * Gets default message when validation for this constraint fail.

--- a/src/validation/ValidatorConstraintInterface.ts
+++ b/src/validation/ValidatorConstraintInterface.ts
@@ -6,7 +6,7 @@ export interface ValidatorConstraintInterface {
   /**
    * Method to be called to perform custom validation over given value.
    */
-  validate(value: any, validationArguments?: ValidationArguments, instance?: any): Promise<boolean> | boolean;
+  validate(value: any, validationArguments?: ValidationArguments): Promise<boolean> | boolean;
 
   /**
    * Gets default message when validation for this constraint fail.


### PR DESCRIPTION
## Description

As described in the ticket, the goal is to get access to the node instance in case nested objects need a parent value for it's validation.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes

fixes #1431
