### PR TITLE
fix: validator type imports for latest @types/validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "@types/validator": "^13.9.0",
+        "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
         "validator": "^13.9.0"
       },
@@ -1716,9 +1716,9 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-NclP0IbzHj/4tJZKFqKh8E7kZdgss+MCUYV9G+TLltFfDA4lFgE4PKPpDIyS2FlcdANIfSx273emkupvChigbw=="
+      "version": "13.11.8",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
+      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -8093,9 +8093,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-NclP0IbzHj/4tJZKFqKh8E7kZdgss+MCUYV9G+TLltFfDA4lFgE4PKPpDIyS2FlcdANIfSx273emkupvChigbw=="
+      "version": "13.11.8",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
+      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ=="
     },
     "@types/yargs": {
       "version": "17.0.13",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:ci": "jest --runInBand --no-cache --coverage --verbose"
   },
   "dependencies": {
-    "@types/validator": "^13.9.0",
+    "@types/validator": "^13.11.8",
     "libphonenumber-js": "^1.10.53",
     "validator": "^13.9.0"
   },

--- a/src/decorator/string/IsAlpha.ts
+++ b/src/decorator/string/IsAlpha.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isAlphaValidator from 'validator/lib/isAlpha';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_ALPHA = 'isAlpha';
 

--- a/src/decorator/string/IsAlphanumeric.ts
+++ b/src/decorator/string/IsAlphanumeric.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isAlphanumericValidator from 'validator/lib/isAlphanumeric';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_ALPHANUMERIC = 'isAlphanumeric';
 

--- a/src/decorator/string/IsBase64.ts
+++ b/src/decorator/string/IsBase64.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isBase64Validator from 'validator/lib/isBase64';
-import type ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_BASE64 = 'isBase64';
 

--- a/src/decorator/string/IsCurrency.ts
+++ b/src/decorator/string/IsCurrency.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isCurrencyValidator from 'validator/lib/isCurrency';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_CURRENCY = 'isCurrency';
 

--- a/src/decorator/string/IsDateString.ts
+++ b/src/decorator/string/IsDateString.ts
@@ -1,6 +1,6 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 import { isISO8601 } from './IsISO8601';
 
 export const IS_DATE_STRING = 'isDateString';

--- a/src/decorator/string/IsDecimal.ts
+++ b/src/decorator/string/IsDecimal.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isDecimalValidator from 'validator/lib/isDecimal';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_DECIMAL = 'isDecimal';
 

--- a/src/decorator/string/IsEmail.ts
+++ b/src/decorator/string/IsEmail.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isEmailValidator from 'validator/lib/isEmail';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_EMAIL = 'isEmail';
 

--- a/src/decorator/string/IsFQDN.ts
+++ b/src/decorator/string/IsFQDN.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isFqdnValidator from 'validator/lib/isFQDN';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_FQDN = 'isFqdn';
 

--- a/src/decorator/string/IsHash.ts
+++ b/src/decorator/string/IsHash.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isHashValidator from 'validator/lib/isHash';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_HASH = 'isHash';
 

--- a/src/decorator/string/IsISO8601.ts
+++ b/src/decorator/string/IsISO8601.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isIso8601Validator from 'validator/lib/isISO8601';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_ISO8601 = 'isIso8601';
 

--- a/src/decorator/string/IsISSN.ts
+++ b/src/decorator/string/IsISSN.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isISSNValidator from 'validator/lib/isISSN';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_ISSN = 'isISSN';
 

--- a/src/decorator/string/IsIdentityCard.ts
+++ b/src/decorator/string/IsIdentityCard.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isIdentityCardValidator from 'validator/lib/isIdentityCard';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_IDENTITY_CARD = 'isIdentityCard';
 

--- a/src/decorator/string/IsMacAddress.ts
+++ b/src/decorator/string/IsMacAddress.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions, isValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isMacAddressValidator from 'validator/lib/isMACAddress';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_MAC_ADDRESS = 'isMacAddress';
 

--- a/src/decorator/string/IsMobilePhone.ts
+++ b/src/decorator/string/IsMobilePhone.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isMobilePhoneValidator from 'validator/lib/isMobilePhone';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_MOBILE_PHONE = 'isMobilePhone';
 

--- a/src/decorator/string/IsNumberString.ts
+++ b/src/decorator/string/IsNumberString.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isNumericValidator from 'validator/lib/isNumeric';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_NUMBER_STRING = 'isNumberString';
 

--- a/src/decorator/string/IsPostalCode.ts
+++ b/src/decorator/string/IsPostalCode.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isPostalCodeValidator from 'validator/lib/isPostalCode';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_POSTAL_CODE = 'isPostalCode';
 

--- a/src/decorator/string/IsStrongPassword.ts
+++ b/src/decorator/string/IsStrongPassword.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import * as validator from 'validator';
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 

--- a/src/decorator/string/IsUUID.ts
+++ b/src/decorator/string/IsUUID.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isUuidValidator from 'validator/lib/isUUID';
-import type ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_UUID = 'isUuid';
 

--- a/src/decorator/string/IsUrl.ts
+++ b/src/decorator/string/IsUrl.ts
@@ -1,7 +1,7 @@
 import { ValidationOptions } from '../ValidationOptions';
 import { buildMessage, ValidateBy } from '../common/ValidateBy';
 import isUrlValidator from 'validator/lib/isURL';
-import ValidatorJS from 'validator';
+import * as ValidatorJS from 'validator';
 
 export const IS_URL = 'isUrl';
 

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -197,7 +197,7 @@ import {
 import { Validator } from '../../src/validation/Validator';
 import { ValidatorOptions } from '../../src/validation/ValidatorOptions';
 import { constraintToString } from '../../src/validation/ValidationUtils';
-import { default as ValidatorJS } from 'validator';
+import * as ValidatorJS from 'validator';
 
 function checkValidValues(
   object: { someProperty: any },


### PR DESCRIPTION
## Description
In https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68121, we fixed validator's types to improve compatibility with node16/nodenext. This fixes missing information that was important to users under certain configurations, but it unfortunately means that type imports in the repo need to be updated to be namespace imports (i.e. can no longer rely on the global validator namespace). This workaround is the way forward.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes

Closes DefinitelyTyped/DefinitelyTyped#68152
fixes #1866
