### PR TITLE
fix: set options from decorator to IsBase64 method

### DIFF
--- a/src/decorator/string/IsBase64.ts
+++ b/src/decorator/string/IsBase64.ts
@@ -26,7 +26,7 @@ export function IsBase64(
       name: IS_BASE64,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isBase64(value),
+        validate: (value, args): boolean => isBase64(value, options),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be base64 encoded', validationOptions),
       },
     },

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -1655,6 +1655,7 @@ describe('IsBase32', () => {
 
 describe('IsBase64', () => {
   const constraint = '';
+  const urlNotSafe = [btoa('malicious_data+/=')]
   const validValues = ['aGVsbG8='];
   const invalidValues = [null, undefined, 'hell*mynameisalex'];
 
@@ -1677,6 +1678,14 @@ describe('IsBase64', () => {
 
   it('should fail if method in validator said that its invalid', () => {
     invalidValues.forEach(value => expect(isBase64(value)).toBeFalsy());
+  });
+
+  it('should fail if method in validator said that its invalid, and i pass a url not safe and set in options urlSafe to true', () => {
+    urlNotSafe.forEach(value => expect(isBase64(value, { urlSafe: true })).toBeFalsy());
+  });
+
+  it('should not fail if method in validator said that its valid, and i pass a url not safe and set in options urlSafe to false', () => {
+    urlNotSafe.forEach(value => expect(isBase64(value, { urlSafe: false })).toBeTruthy());
   });
 
   it('should return error object with proper data', () => {

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -1655,7 +1655,7 @@ describe('IsBase32', () => {
 
 describe('IsBase64', () => {
   const constraint = '';
-  const urlNotSafe = [btoa('malicious_data+/=')]
+  const urlNotSafe = [btoa('malicious_data+/=')];
   const validValues = ['aGVsbG8='];
   const invalidValues = [null, undefined, 'hell*mynameisalex'];
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
Now decorator IsBase64 passes options to IsBase64 method.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [ ] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #2374
