### PR TITLE
feat: Pass propertyName to ValidateIf condition function

### DIFF
--- a/src/decorator/common/ValidateIf.ts
+++ b/src/decorator/common/ValidateIf.ts
@@ -8,7 +8,7 @@ import { getMetadataStorage } from '../../metadata/MetadataStorage';
  * Ignores the other validators on a property when the provided condition function returns false.
  */
 export function ValidateIf(
-  condition: (object: any, value: any) => boolean,
+  condition: (object: any, value: any, propertyName: string) => boolean,
   validationOptions?: ValidationOptions
 ): PropertyDecorator {
   return function (object: object, propertyName: string): void {

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -184,7 +184,7 @@ export class ValidationExecutor {
     const validationError = this.generateValidationError(object, value, propertyName);
     validationErrors.push(validationError);
 
-    const canValidate = this.conditionalValidations(object, value, conditionalValidationMetadatas);
+    const canValidate = this.conditionalValidations(object, value, propertyName, conditionalValidationMetadatas);
     if (!canValidate) {
       return;
     }
@@ -242,9 +242,14 @@ export class ValidationExecutor {
     return validationError;
   }
 
-  private conditionalValidations(object: object, value: any, metadatas: ValidationMetadata[]): ValidationMetadata[] {
+  private conditionalValidations(
+    object: object,
+    value: any,
+    propertyName: string,
+    metadatas: ValidationMetadata[]
+  ): ValidationMetadata[] {
     return metadatas
-      .map(metadata => metadata.constraints[0](object, value))
+      .map(metadata => metadata.constraints[0](object, value, propertyName))
       .reduce((resultA, resultB) => resultA && resultB, true);
   }
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
This PR passes the decorated property name to the condition function of `ValidateIf` decorator, so that it's possible to apply rules using the property name, e.g. build custom decorator to validate only if the property is presented in the object. 
```
function IsOptional() {
  return ValidateIf((object, value, propertyName) =>
    object.hasOwnProperty(propertyName)
  );
}
```

P.S. No issue has been created since it's a really minor change.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #[issue number], fixes #[issue number]
