### PR TITLE
change(isMobilePhone): updated locale typing to better reflect ValidatorJS functionality

### DIFF
--- a/src/decorator/string/IsMobilePhone.ts
+++ b/src/decorator/string/IsMobilePhone.ts
@@ -19,7 +19,7 @@ export const IS_MOBILE_PHONE = 'isMobilePhone';
  */
 export function isMobilePhone(
   value: unknown,
-  locale?: ValidatorJS.MobilePhoneLocale,
+  locale?: 'any' | ValidatorJS.MobilePhoneLocale | ValidatorJS.MobilePhoneLocale[],
   options?: ValidatorJS.IsMobilePhoneOptions
 ): boolean {
   return typeof value === 'string' && isMobilePhoneValidator(value, locale, options);
@@ -38,7 +38,7 @@ export function isMobilePhone(
  * If given value is not a string, then it returns false.
  */
 export function IsMobilePhone(
-  locale?: ValidatorJS.MobilePhoneLocale,
+  locale?: 'any' | ValidatorJS.MobilePhoneLocale | ValidatorJS.MobilePhoneLocale[],
   options?: ValidatorJS.IsMobilePhoneOptions,
   validationOptions?: ValidationOptions
 ): PropertyDecorator {


### PR DESCRIPTION
## Description
Updated typings for IsMobilePhone decorator usage to better reflect of the actual functionality of ValidatorJS's validation.

Notable changes:
* support setting locale as `"any"` to validate against any locale.
* allow locale to be an array of locales to validate against multiple locales.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [X] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [X] the pull request targets the *default* branch of the repository (`develop`)
- [X] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [X] tests are added for the changes I made (if any source code was modified)
- [X] documentation added or updated
- [X] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #2489
