### PR TITLE
fix: array unique duplicated null or undefined

### DIFF
--- a/src/decorator/array/ArrayUnique.ts
+++ b/src/decorator/array/ArrayUnique.ts
@@ -12,7 +12,9 @@ export function arrayUnique(array: unknown[], identifier?: ArrayUniqueIdentifier
   if (!Array.isArray(array)) return false;
 
   if (identifier) {
-    array = array.map(o => (o != null ? identifier(o) : o));
+    array = array.map(o => (o != null ? identifier(o) : o)).filter(o => o != null);
+
+    if (array.length === 0) return true;
   }
 
   const uniqueItems = array.filter((a, b, c) => c.indexOf(a) === b);

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -4572,7 +4572,7 @@ describe('ArrayUnique with identifier', () => {
     ['world', 'hello', 'superman'],
     ['world', 'superman', 'hello'],
     ['superman', 'world', 'hello'],
-    ['1', '2', null, undefined],
+    ['1', '2', null, null, undefined, undefined],
   ].map(list => list.map(name => ({ name })));
   const invalidValues: any[] = [
     null,


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

The `arrayUnique` function was not bypassing duplicated `null` or `undefined` values for the `identifier` function. A filter iterator was added at line 15, fixing the bug.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #2498
