### PR TITLE
fix: pass IsBase64 options correctly

### DIFF
--- a/src/decorator/string/IsBase64.ts
+++ b/src/decorator/string/IsBase64.ts
@@ -26,7 +26,7 @@ export function IsBase64(
       name: IS_BASE64,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isBase64(value),
+        validate: (value, args): boolean => isBase64(value, args?.constraints[0]),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be base64 encoded', validationOptions),
       },
     },

--- a/src/decorator/string/IsBase64.ts
+++ b/src/decorator/string/IsBase64.ts
@@ -26,7 +26,7 @@ export function IsBase64(
       name: IS_BASE64,
       constraints: [options],
       validator: {
-        validate: (value, args): boolean => isBase64(value, args?.constraints[0]),
+        validate: (value, args): boolean => isBase64(value, options),
         defaultMessage: buildMessage(eachPrefix => eachPrefix + '$property must be base64 encoded', validationOptions),
       },
     },

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -1658,17 +1658,27 @@ describe('IsBase64', () => {
   const validValues = ['aGVsbG8='];
   const invalidValues = [null, undefined, 'hell*mynameisalex'];
 
+  const validBase64UrlValues = ['dGVzdA', 'dGV_zdA'];
+  const invalidBase64UrlValues = [null, undefined, 'dGVzdA=', 'MTIzNDU2Nzg5!!', 'SGVsbG8+V29ybGQ='];
+
   class MyClass {
     @IsBase64()
     someProperty: string;
   }
 
-  it('should not fail if validator.validate said that its valid', () => {
-    return checkValidValues(new MyClass(), validValues);
+  class MyClassWithConstraint {
+    @IsBase64({ urlSafe: true })
+    someProperty: string;
+  }
+
+  it('should not fail if validator.validate said that its valid', async () => {
+    await checkValidValues(new MyClass(), validValues);
+    await checkValidValues(new MyClassWithConstraint(), validBase64UrlValues);
   });
 
-  it('should fail if validator.validate said that its invalid', () => {
-    return checkInvalidValues(new MyClass(), invalidValues);
+  it('should fail if validator.validate said that its invalid', async () => {
+    await checkInvalidValues(new MyClass(), invalidValues);
+    await checkInvalidValues(new MyClassWithConstraint(), invalidBase64UrlValues);
   });
 
   it('should not fail if method in validator said that its valid', () => {


### PR DESCRIPTION
## Description
In the IsBase64 decorator, constraints weren’t passed to isBase64. This issue has been fixed in this PR.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #2548
closes #2383
