### PR TITLE
feat: add standard schema support and associated tests

### DIFF
--- a/src/standard-schema/StandardSchema.ts
+++ b/src/standard-schema/StandardSchema.ts
@@ -1,0 +1,110 @@
+/**
+ * The Standard Schema interface.
+ */
+export type StandardSchemaV1<Input = unknown, Output = Input> = {
+  /**
+   * The Standard Schema properties.
+   */
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>;
+};
+
+export declare namespace StandardSchemaV1 {
+  /**
+   * The Standard Schema properties interface.
+   */
+  export interface Props<Input = unknown, Output = Input> {
+    /**
+     * The version number of the standard.
+     */
+    readonly version: 1;
+    /**
+     * The vendor name of the schema library.
+     */
+    readonly vendor: string;
+    /**
+     * Validates unknown input values.
+     */
+    readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>;
+    /**
+     * Inferred types associated with the schema.
+     */
+    readonly types?: Types<Input, Output> | undefined;
+  }
+
+  /**
+   * The result interface of the validate function.
+   */
+  export type Result<Output> = SuccessResult<Output> | FailureResult;
+
+  /**
+   * The result interface if validation succeeds.
+   */
+  export interface SuccessResult<Output> {
+    /**
+     * The typed output value.
+     */
+    readonly value: Output;
+    /**
+     * The non-existent issues.
+     */
+    readonly issues?: undefined;
+  }
+
+  /**
+   * The result interface if validation fails.
+   */
+  export interface FailureResult {
+    /**
+     * The issues of failed validation.
+     */
+    readonly issues: ReadonlyArray<Issue>;
+  }
+
+  /**
+   * The issue interface of the failure output.
+   */
+  export interface Issue {
+    /**
+     * The error message of the issue.
+     */
+    readonly message: string;
+    /**
+     * The path of the issue, if any.
+     */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+  }
+
+  /**
+   * The path segment interface of the issue.
+   */
+  export interface PathSegment {
+    /**
+     * The key representing a path segment.
+     */
+    readonly key: PropertyKey;
+  }
+
+  /**
+   * The Standard Schema types interface.
+   */
+  export interface Types<Input = unknown, Output = Input> {
+    /**
+     * The input type of the schema.
+     */
+    readonly input: Input;
+    /**
+     * The output type of the schema.
+     */
+    readonly output: Output;
+  }
+
+  /**
+   * Infers the input type of a Standard Schema.
+   */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<Schema['~standard']['types']>['input'];
+
+  /**
+   * Infers the output type of a Standard Schema.
+   */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<Schema['~standard']['types']>['output'];
+}

--- a/src/standard-schema/ValidationSchemaToStandardSchemaAdapters.ts
+++ b/src/standard-schema/ValidationSchemaToStandardSchemaAdapters.ts
@@ -1,0 +1,31 @@
+import { ValidationError } from '../validation/ValidationError';
+import { StandardSchemaV1 } from './StandardSchema';
+
+export function validationErrorToIssues(valError: ValidationError): StandardSchemaV1.Issue[] {
+  const results: StandardSchemaV1.Issue[] = [];
+  const errorsToConvert: { path: string[]; value: ValidationError }[] = [{ path: [], value: valError }];
+
+  while (errorsToConvert.length > 0) {
+    // this is safe, since we check the length of the array before
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const error = errorsToConvert.pop()!;
+
+    const newPath = [...error.path, error.value.property];
+
+    Object.values(error.value.constraints ?? {}).forEach(constraintMessage =>
+      results.push({
+        message: constraintMessage,
+        path: newPath,
+      })
+    );
+
+    error.value.children?.reverse().forEach(childError =>
+      errorsToConvert.push({
+        path: newPath,
+        value: childError,
+      })
+    );
+  }
+
+  return results;
+}

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -2,11 +2,34 @@ import { ValidationError } from './ValidationError';
 import { ValidatorOptions } from './ValidatorOptions';
 import { ValidationExecutor } from './ValidationExecutor';
 import { ValidationOptions } from '../decorator/ValidationOptions';
+import { StandardSchemaV1 } from '../standard-schema/StandardSchema';
+import { validationErrorToIssues } from '../standard-schema/ValidationSchemaToStandardSchemaAdapters';
 
 /**
  * Validator performs validation of the given object based on its metadata.
  */
-export class Validator {
+export class Validator implements StandardSchemaV1 {
+  // -------------------------------------------------------------------------
+  // Standard Schema implementation
+  // -------------------------------------------------------------------------
+  '~standard': StandardSchemaV1.Props<unknown, unknown> = {
+    version: 1,
+
+    vendor: 'class-validator',
+
+    validate: async (input: unknown) => {
+      const validationResults = await this.validate(input as object);
+
+      const mappedErrors: StandardSchemaV1.Issue[] = [];
+
+      validationResults.forEach(valError => mappedErrors.push(...validationErrorToIssues(valError)));
+
+      if (mappedErrors.length > 0) return { issues: mappedErrors };
+
+      return { value: input };
+    },
+  };
+
   // -------------------------------------------------------------------------
   // Public Methods
   // -------------------------------------------------------------------------

--- a/test/functional/standard-schema.spec.ts
+++ b/test/functional/standard-schema.spec.ts
@@ -1,0 +1,83 @@
+import { IsString, IsUrl, IsOptional, ValidateNested, MinLength } from '../../src/decorator/decorators';
+import { StandardSchemaV1 } from '../../src/standard-schema/StandardSchema';
+import { validationErrorToIssues } from '../../src/standard-schema/ValidationSchemaToStandardSchemaAdapters';
+import { Validator } from '../../src/validation/Validator';
+
+const validator = new Validator();
+
+describe('ValidationErrorToStandardSchemaIssues', () => {
+  it('Should correctly map the Validation Errors into standard schema issues', async () => {
+    class NestedClass {
+      @IsString()
+      public name: string;
+
+      @IsUrl()
+      public url: string;
+
+      @IsOptional()
+      @ValidateNested()
+      public insideNested: NestedClass;
+
+      constructor(url: string, name: any, insideNested?: NestedClass) {
+        this.url = url;
+        this.name = name;
+        this.insideNested = insideNested;
+      }
+    }
+
+    class RootClass {
+      @IsString()
+      @MinLength(15)
+      public title: string;
+
+      @ValidateNested()
+      public nestedObj: NestedClass;
+
+      @ValidateNested({ each: true })
+      public nestedArr: NestedClass[];
+
+      constructor() {
+        this.title = 5 as any;
+        this.nestedObj = new NestedClass('invalid-url', 5, new NestedClass('invalid-url', 5));
+        this.nestedArr = [new NestedClass('invalid-url', 5), new NestedClass('invalid-url', 5)];
+      }
+    }
+
+    const validationErrors = await validator.validate(new RootClass());
+    const mappedErrors: StandardSchemaV1.Issue[] = [];
+
+    validationErrors.forEach(valError => mappedErrors.push(...validationErrorToIssues(valError)));
+
+    expect(mappedErrors).toHaveLength(10);
+
+    expect(mappedErrors[0].path).toStrictEqual(['title']);
+    expect(mappedErrors[0].message).toStrictEqual('title must be longer than or equal to 15 characters');
+
+    expect(mappedErrors[1].path).toStrictEqual(['title']);
+    expect(mappedErrors[1].message).toStrictEqual('title must be a string');
+
+    expect(mappedErrors[2].path).toStrictEqual(['nestedObj', 'name']);
+    expect(mappedErrors[2].message).toStrictEqual('name must be a string');
+
+    expect(mappedErrors[3].path).toStrictEqual(['nestedObj', 'url']);
+    expect(mappedErrors[3].message).toStrictEqual('url must be a URL address');
+
+    expect(mappedErrors[4].path).toStrictEqual(['nestedObj', 'insideNested', 'name']);
+    expect(mappedErrors[4].message).toStrictEqual('name must be a string');
+
+    expect(mappedErrors[5].path).toStrictEqual(['nestedObj', 'insideNested', 'url']);
+    expect(mappedErrors[5].message).toStrictEqual('url must be a URL address');
+
+    expect(mappedErrors[6].path).toStrictEqual(['nestedArr', '0', 'name']);
+    expect(mappedErrors[6].message).toStrictEqual('name must be a string');
+
+    expect(mappedErrors[7].path).toStrictEqual(['nestedArr', '0', 'url']);
+    expect(mappedErrors[7].message).toStrictEqual('url must be a URL address');
+
+    expect(mappedErrors[8].path).toStrictEqual(['nestedArr', '1', 'name']);
+    expect(mappedErrors[8].message).toStrictEqual('name must be a string');
+
+    expect(mappedErrors[9].path).toStrictEqual(['nestedArr', '1', 'url']);
+    expect(mappedErrors[9].message).toStrictEqual('url must be a URL address');
+  });
+});


### PR DESCRIPTION
## Description
This PR adds the support for standard schema, by copying their interface, extending the validator with it, and mapping class validator's "Validation Error" type to standard schema's "Issue". 

I also wrote some tests, which are the same as the "nested validation" ones.

Since this function would be in the hot path, I tried to make it optimized, by avoiding recursion and preferring mutation to copy.

Supporting the Standard Schema interface is important, since it's blocking the adoption of it by NestJs (see related [nestjs/nest/#14539](https://github.com/nestjs/nest/issues/14539))

edit: by itself, the PR in its current form would not be enough. We need to add a wrapper function, that takes a schema as input, and that outputs a validator containing the schema. Let me know if it sounds good to you.

## Disclosure
I had to ignore the ESLint warning when copying the standard schema interface.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
addresses #2577 
