### PR TITLE
build: update validator to 13.15.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
-        "@types/validator": "^13.11.8",
+        "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
-        "validator": "^13.9.0"
+        "validator": "^13.15.20"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -1716,9 +1716,10 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.11.8",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
-      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ=="
+      "version": "13.15.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
+      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -6453,9 +6454,10 @@
       "dev": true
     },
     "node_modules/validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -8019,9 +8021,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.11.8",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
-      "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ=="
+      "version": "13.15.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
+      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q=="
     },
     "@types/yargs": {
       "version": "17.0.13",
@@ -11367,9 +11369,9 @@
       }
     },
     "validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw=="
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "test:ci": "jest --runInBand --no-cache --coverage --verbose"
   },
   "dependencies": {
-    "@types/validator": "^13.11.8",
+    "@types/validator": "^13.15.3",
     "libphonenumber-js": "^1.11.1",
-    "validator": "^13.9.0"
+    "validator": "^13.15.20"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/src/decorator/string/IsRgbColor.ts
+++ b/src/decorator/string/IsRgbColor.ts
@@ -10,9 +10,12 @@ export const IS_RGB_COLOR = 'isRgbColor';
  * If given value is not a string, then it returns false.
  */
 export function isRgbColor(value: unknown, includePercentValues?: boolean): boolean {
-  return typeof value === 'string' && isRgbColorValidator(value, {
-    includePercentValues
-  });
+  return (
+    typeof value === 'string' &&
+    isRgbColorValidator(value, {
+      includePercentValues,
+    })
+  );
 }
 
 /**

--- a/src/decorator/string/IsRgbColor.ts
+++ b/src/decorator/string/IsRgbColor.ts
@@ -10,7 +10,9 @@ export const IS_RGB_COLOR = 'isRgbColor';
  * If given value is not a string, then it returns false.
  */
 export function isRgbColor(value: unknown, includePercentValues?: boolean): boolean {
-  return typeof value === 'string' && isRgbColorValidator(value, includePercentValues);
+  return typeof value === 'string' && isRgbColorValidator(value, {
+    includePercentValues
+  });
 }
 
 /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -265,8 +265,6 @@ function checkReturnedError(
   return Promise.all(promises);
 }
 
-const validator = new Validator();
-
 describe('IsDefined', () => {
   const validValues = [0, 1, true, false, '', '0', '1234', -1];
   const invalidValues: any[] = [null, undefined];
@@ -3117,9 +3115,13 @@ describe('IsJWT', () => {
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb3JlbSI6Imlwc3VtIn0.ymiJSsMJXR6tMSr8G9usjQ15_8hKPDv_CArLhxw28MI',
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkb2xvciI6InNpdCIsImFtZXQiOlsibG9yZW0iLCJpcHN1bSJdfQ.rRpe04zbWbbJjwM43VnHzAboDzszJtGrNsUxaqQ-GQ8',
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqb2huIjp7ImFnZSI6MjUsImhlaWdodCI6MTg1fSwiamFrZSI6eyJhZ2UiOjMwLCJoZWlnaHQiOjI3MH19.YRLPARDmhGMC3BBk_OhtwwK21PIkVCqQe8ncIRPKo-E',
+  ];
+  const invalidValues = [
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    '$Zs.ewu.su84',
+    'ks64$S/9.dy$§kz.3sd73b',
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ', // No signature
   ];
-  const invalidValues = ['eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', '$Zs.ewu.su84', 'ks64$S/9.dy$§kz.3sd73b'];
 
   class MyClass {
     @IsJWT()
@@ -3533,7 +3535,7 @@ describe('IsUrl', () => {
 
 describe('IsUUID', () => {
   const validValues = [
-    'A987FBC9-4BED-3078-CF07-9141BA07C9F3',
+    'A987FBC9-4BED-3078-8F07-9141BA07C9F3',
     'A987FBC9-4BED-4078-8F07-9141BA07C9F3',
     'A987FBC9-4BED-5078-AF07-9141BA07C9F3',
   ];
@@ -3547,6 +3549,7 @@ describe('IsUUID', () => {
     '934859',
     '987FBC9-4BED-3078-CF07A-9141BA07C9F3',
     'AAAAAAAA-1111-1111-AAAG-111111111111',
+    'A987FBC9-4BED-3078-CF07-9141BA07C9F3', // does not conform to RFC9562 UUID
   ];
 
   class MyClass {
@@ -3578,7 +3581,12 @@ describe('IsUUID', () => {
 });
 
 describe('IsUUID v3', () => {
-  const validValues = ['A987FBC9-4BED-3078-CF07-9141BA07C9F3'];
+  const validValues = [
+    'A987FBC9-4BED-3078-8F07-9141BA07C9F3',
+    'A987FBC9-4BED-3078-9F07-9141BA07C9F3',
+    'A987FBC9-4BED-3078-AF07-9141BA07C9F3',
+    'A987FBC9-4BED-3078-BF07-9141BA07C9F3',
+  ];
   const invalidValues = [
     null,
     undefined,
@@ -3588,6 +3596,7 @@ describe('IsUUID v3', () => {
     'AAAAAAAA-1111-1111-AAAG-111111111111',
     'A987FBC9-4BED-4078-8F07-9141BA07C9F3',
     'A987FBC9-4BED-5078-AF07-9141BA07C9F3',
+    'A987FBC9-4BED-3078-CF07-9141BA07C9F3', // does not conform to RFC9562 UUID
   ];
 
   class MyClass {


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

Update validator from 13.9.0 to 13.15.20, which resolves CVE-2025-56200

This PR aims to resolves CVE-2025-56200 and not on adding any new features in validator from 13.9.0 - 13.15.20.

Changelog: https://github.com/validatorjs/validator.js/compare/13.9.0...13.15.20

- isUUID need to conform to RFC9562 (see https://github.com/validatorjs/validator.js/pull/2421)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #2636 
