### PR TITLE
release: 0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 _This changelog follows the [keep a changelog][keep-a-changelog]_ format to maintain a human readable changelog.
 
+## [0.14.4](https://github.com/typestack/class-validator/compare/v0.14.3...v0.14.4) (2026-01-13)
+
+- Updated validator.js to 13.15.22 ([#2649](https://github.com/typestack/class-validator/pull/2649))
+
 ## [0.14.3](https://github.com/typestack/class-validator/compare/v0.14.1...v0.14.3) (2025-11-24)
 
 - Fixed a vulnerability by bumping validator.js ([#2638](https://github.com/typestack/class-validator/pull/2638) by [@weikangchia](https://github.com/weikangchia))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "class-validator",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "class-validator",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-validator",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Decorator-based property validation for classes.",
   "author": "TypeStack contributors",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Updated validator.js to 13.15.22 ([#2649](https://github.com/typestack/class-validator/pull/2649))

## Changes

- docs: add changelog for 0.14.4
- build: bump version to 0.14.4