### PR TITLE
chore: publish 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 _This changelog follows the [keep a changelog][keep-a-changelog]_ format to maintain a human readable changelog.
 
-## [0.15.0](https://github.com/typestack/class-validator/compare/v0.14.4...v0.15.0) (2026-02-25)
+## [0.15.1](https://github.com/typestack/class-validator/compare/v0.14.4...v0.15.1) (2026-02-26)
 
 ### BREAKING CHANGES
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "class-validator",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "class-validator",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "class-validator",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Decorator-based property validation for classes.",
   "author": "TypeStack contributors",
   "license": "MIT",


### PR DESCRIPTION
I don't have permission to delete the 0.15.0 tag (which contains the right code but the wrong version number in package.json, so it's unreleasable). Let's just release 0.15.1.