### PR TITLE
fix: isISO31661Alpha2 currently allowing lowercase characters (#2629)

### DIFF
--- a/src/decorator/string/IsISO31661Alpha2.ts
+++ b/src/decorator/string/IsISO31661Alpha2.ts
@@ -8,7 +8,7 @@ export const IS_ISO31661_ALPHA_2 = 'isISO31661Alpha2';
  * Check if the string is a valid [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) officially assigned country code.
  */
 export function isISO31661Alpha2(value: unknown): boolean {
-  return typeof value === 'string' && isISO31661Alpha2Validator(value);
+  return typeof value === 'string' && value === value.toUpperCase() && isISO31661Alpha2Validator(value);
 }
 
 /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -4544,6 +4544,11 @@ describe('IsISO31661Alpha3', () => {
     const invalidValues = [undefined, null, '', 'FR', 'fR', 'GB', 'PT', 'CM', 'JP', 'PM', 'ZW'];
     return checkInvalidValues(new MyClass(), invalidValues);
   });
+
+  it('should fail for lowercase values', () => {
+    const invalidValues = ['tw', 'us', 'jp', 'aE'];
+    return checkInvalidValues(new MyClass(), invalidValues);
+  });
 });
 
 describe('IsISO31661Numeric', () => {


### PR DESCRIPTION
## Description
Added a strict uppercase check in `isISO31661Alpha2` before delegating to `validator.js`. This prevents lowercase characters from bypassing the validation. Also added a test case in `IsISO31661Alpha2.spec.ts` to ensure lowercase values are correctly rejected.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #2629