### PR TITLE
fix: isObject should return false for functions

### DIFF
--- a/src/decorator/typechecker/IsObject.ts
+++ b/src/decorator/typechecker/IsObject.ts
@@ -8,7 +8,7 @@ export const IS_OBJECT = 'isObject';
  * Returns false if the value is not an object.
  */
 export function isObject<T = object>(value: unknown): value is T {
-  return value != null && (typeof value === 'object' || typeof value === 'function') && !Array.isArray(value);
+  return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -3166,6 +3166,10 @@ describe('IsObject', () => {
     '[]',
     [],
     [{ key: 'value' }],
+    () => 'function',
+    function namedFn() {
+      return 'named function';
+    },
   ];
 
   class MyClass {


### PR DESCRIPTION
## Bug

The `isObject` / `@IsObject()` validator incorrectly accepts function values as valid objects.

The README documentation is explicit (emphasis mine):

> `@IsObject()` — Checks if the object is valid Object (**null, functions, arrays will return false**).

However, the implementation in `src/decorator/typechecker/IsObject.ts` includes `typeof value === 'function'` in the condition:

```ts
// before
return value != null && (typeof value === 'object' || typeof value === 'function') && !Array.isArray(value);
```

This causes `isObject(() => 'x')` to return `true`, which contradicts the documented behavior.

Closes #2515

## Root cause

The `|| typeof value === 'function'` branch was included in the check, presumably to mirror a generic "non-primitive" guard. Since functions are not plain data objects, the docs correctly exclude them — the implementation just didn't follow through.

## Fix

Remove the `typeof value === 'function'` branch:

```ts
// after
return value != null && typeof value === 'object' && !Array.isArray(value);
```

## Test evidence

Two function values (`() => 'function'` and a named function expression) were added to the `invalidValues` array in the `IsObject` test suite. Before the fix, 2 tests failed; after the fix, all 5 `IsObject` tests pass and the full suite (806 tests) continues to pass.

```
PASS test/functional/validation-functions-and-decorators.spec.ts
  IsObject
    ✓ should not fail if validator.validate said that its valid
    ✓ should fail if validator.validate said that its invalid
    ✓ should not fail if method in validator said that its valid
    ✓ should fail if method in validator said that its invalid
    ✓ should return error object with proper data

Tests: 806 passed, 806 total
```