### PR TITLE
feat: add IsMutuallyExclusiveWith decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ isBoolean(value);
 | `@ArrayUnique(identifier?: (o) => any)`                | Checks if all array's values are unique. Comparison for objects is reference-based. Optional function can be speciefied which return value will be used for the comparsion.                           |
 | **Object validation decorators**                       |
 | `@IsInstance(value: any)`                              | Checks if the property is an instance of the passed value.                                                                                                                                            |
+| `@IsMutuallyExclusiveWith(property: string)`           | Checks if the property and the given related property are not both provided at the same time.                                                                                                         |
 | **Other decorators**                                   |                                                                                                                                                                                                       |
 | `@Allow()`                                             | Prevent stripping off the property when no other constraint is specified for it.                                                                                                                      |
 

--- a/src/decorator/common/IsMutuallyExclusiveWith.ts
+++ b/src/decorator/common/IsMutuallyExclusiveWith.ts
@@ -1,0 +1,39 @@
+import { ValidationArguments } from '../../validation/ValidationArguments';
+import { ValidationOptions } from '../ValidationOptions';
+import { ValidateBy, buildMessage } from './ValidateBy';
+
+export const IS_MUTUALLY_EXCLUSIVE_WITH = 'isMutuallyExclusiveWith';
+
+/**
+ * Checks if the value and the value of the related property are not both present at the same time.
+ */
+export function isMutuallyExclusiveWith(
+  value: unknown,
+  relatedPropertyName: string,
+  args?: ValidationArguments
+): boolean {
+  const relatedValue = (args?.object as any)?.[relatedPropertyName];
+  const isValuePresent = value !== undefined && value !== null;
+  const isRelatedPresent = relatedValue !== undefined && relatedValue !== null;
+  return !(isValuePresent && isRelatedPresent);
+}
+
+/**
+ * Checks if the property and the given related property are not both provided at the same time.
+ */
+export function IsMutuallyExclusiveWith(property: string, validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: IS_MUTUALLY_EXCLUSIVE_WITH,
+      constraints: [property],
+      validator: {
+        validate: (value, args): boolean => isMutuallyExclusiveWith(value, args?.constraints[0], args),
+        defaultMessage: buildMessage(
+          eachPrefix => eachPrefix + `$property and ${property} cannot both be provided`,
+          validationOptions
+        ),
+      },
+    },
+    validationOptions
+  );
+}

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -23,6 +23,7 @@ export * from './common/IsEmpty';
 export * from './common/IsNotEmpty';
 export * from './common/IsIn';
 export * from './common/IsNotIn';
+export * from './common/IsMutuallyExclusiveWith';
 
 // -------------------------------------------------------------------------
 // Number checkers

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -7,6 +7,7 @@ import {
   IsNegative,
   Contains,
   Equals,
+  IsMutuallyExclusiveWith,
   MinDate,
   MaxDate,
   IsAlpha,
@@ -122,6 +123,7 @@ import {
   maxLength,
   isFirebasePushId,
   equals,
+  isMutuallyExclusiveWith,
   notEquals,
   isEmpty,
   isNotEmpty,
@@ -353,6 +355,52 @@ describe('Equals', () => {
     const validationType = 'equals';
     const message = 'someProperty must be equal to ' + constraintToString(constraint);
     return checkReturnedError(new MyClass(), invalidValues, validationType, message);
+  });
+});
+
+describe('IsMutuallyExclusiveWith', () => {
+  class MyClass {
+    @IsMutuallyExclusiveWith('propertyB')
+    someProperty: string;
+
+    propertyB: string;
+  }
+
+  it('should not fail if only one property is provided', () => {
+    const model1 = new MyClass();
+    const model2 = new MyClass();
+    model2.propertyB = 'bar';
+
+    return Promise.all([checkValidValues(model1, ['foo']), checkValidValues(model2, [undefined])]);
+  });
+
+  it('should not fail if neither property is provided', () => {
+    const model = new MyClass();
+    return checkValidValues(model, [undefined]);
+  });
+
+  it('should fail if both properties are provided', () => {
+    const model = new MyClass();
+    model.propertyB = 'bar';
+
+    return checkInvalidValues(model, ['foo']);
+  });
+
+  it('should not fail if method in validator said that its valid', () => {
+    expect(isMutuallyExclusiveWith('foo', 'propertyB', { object: {} } as any)).toBeTruthy();
+  });
+
+  it('should fail if method in validator said that its invalid', () => {
+    expect(isMutuallyExclusiveWith('foo', 'propertyB', { object: { propertyB: 'bar' } } as any)).toBeFalsy();
+  });
+
+  it('should return error object with proper data', () => {
+    const model = new MyClass();
+    model.propertyB = 'bar';
+
+    const validationType = 'isMutuallyExclusiveWith';
+    const message = 'someProperty and propertyB cannot both be provided';
+    return checkReturnedError(model, ['foo'], validationType, message);
   });
 });
 


### PR DESCRIPTION
## Description

Adds a new `@IsMutuallyExclusiveWith(property: string)` decorator that checks
a property and a related property are not both provided at the same time.

This is useful for DTOs/models where exactly one of two mutually exclusive
fields should be set — e.g. "provide either `emailAddress` or `phoneNumber`,
not both".

## Example

\`\`\`typescript
class ContactDto {
  @IsMutuallyExclusiveWith('phoneNumber')
  emailAddress?: string;

  phoneNumber?: string;
}
\`\`\`

Validation fails only when **both** `emailAddress` and `phoneNumber` are
present (not `undefined`/`null`). It passes when either one, or neither, is set.

## Changes

- Added `src/decorator/common/IsMutuallyExclusiveWith.ts`
- Exported the new decorator/function from `src/decorator/decorators.ts`
- Added tests in `test/functional/validation-functions-and-decorators.spec.ts`
- Documented the decorator in `README.md` 

## Checklist

- [x] `npm test` passes
- [x] `npm run lint:check` passes
- [x] `npm run prettier:check` passes
- [x] Docs updated (README)