### PR TITLE
perf: improve ArrayUnique lookup performance

### DIFF
--- a/src/decorator/array/ArrayUnique.ts
+++ b/src/decorator/array/ArrayUnique.ts
@@ -11,12 +11,8 @@ export type ArrayUniqueIdentifier<T = any> = (o: T) => any;
 export function arrayUnique(array: unknown[], identifier?: ArrayUniqueIdentifier): boolean {
   if (!Array.isArray(array)) return false;
 
-  if (identifier) {
-    array = array.map(o => (o != null ? identifier(o) : o));
-  }
-
-  const uniqueItems = array.filter((a, b, c) => c.indexOf(a) === b);
-  return array.length === uniqueItems.length;
+  const values = identifier ? array.map(o => (o != null ? identifier(o) : o)) : array;
+  return new Set(values).size === values.length;
 }
 
 /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -5025,6 +5025,24 @@ describe('ArrayUnique', () => {
     invalidValues.forEach(value => expect(arrayUnique(value)).toBeFalsy());
   });
 
+  it('should compare objects by reference', () => {
+    const object = { name: 'test' };
+
+    expect(arrayUnique([object, { name: 'test' }])).toBeTruthy();
+    expect(arrayUnique([object, object])).toBeFalsy();
+  });
+
+  it('should use SameValueZero semantics for NaN', () => {
+    expect(arrayUnique([1, NaN, 2])).toBeTruthy();
+    expect(arrayUnique([NaN, NaN])).toBeFalsy();
+  });
+
+  it('should treat sparse array items as undefined', () => {
+    expect(arrayUnique([, 1])).toBeTruthy();
+    expect(arrayUnique([, , 1])).toBeFalsy();
+    expect(arrayUnique([undefined, , 1])).toBeFalsy();
+  });
+
   it('should return error object with proper data', () => {
     const validationType = 'arrayUnique';
     const message = "All someProperty's elements must be unique";
@@ -5067,6 +5085,19 @@ describe('ArrayUnique with identifier', () => {
 
   it('should fail if method in validator said that its invalid', () => {
     invalidValues.forEach(value => expect(arrayUnique(value, identifier)).toBeFalsy());
+  });
+
+  it('should call the identifier for every non-null value before checking uniqueness', () => {
+    const visitedNames: string[] = [];
+    const trackingIdentifier = (value: { name: string }): string => {
+      visitedNames.push(value.name);
+      return value.name;
+    };
+
+    expect(
+      arrayUnique([{ name: 'duplicate' }, { name: 'duplicate' }, { name: 'last' }], trackingIdentifier)
+    ).toBeFalsy();
+    expect(visitedNames).toEqual(['duplicate', 'duplicate', 'last']);
   });
 
   it('should return error object with proper data', () => {


### PR DESCRIPTION
Replaces the `filter` and `indexOf` implementation in `arrayUnique` with `Set`-based duplicate detection.

For arrays containing distinct values, the current implementation has O(n²) worst-case time complexity. The new implementation uses O(n) expected time while preserving identifier-based comparison and reference-based object comparison.

This also fixes the handling of `NaN` by using JavaScript's SameValueZero equality semantics:

- a single `NaN`, or one `NaN` among otherwise distinct values, is accepted;
- multiple `NaN` values are rejected as duplicates;
- sparse array holes are treated as `undefined`, following normal `Set` iteration semantics.

Tests were added for object reference comparison, `NaN`, sparse arrays, and identifier evaluation.

## Checklist

- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated (not applicable; the public API and documented behavior are unchanged)
- [x] I have run the project locally and verified that there are no errors

Validation completed successfully:

- 677 functional tests
- ES2015 build
- ESM5 build
- CommonJS build
- UMD build
- Type declarations build

### Fixes

Fixes #2690
